### PR TITLE
Clarify when affine needs to be called.

### DIFF
--- a/src/amcl-extensions/pairing_BN254.c
+++ b/src/amcl-extensions/pairing_BN254.c
@@ -25,12 +25,6 @@ void compute_pairing(FP12_BN254 *pairing_out,
                      ECP_BN254 *g1_point,
                      ECP2_BN254 *g2_point)
 {
-    // TODO: Why is this necessary?
-    // (it looks like only _add and _sub don't convert to affine)
-    // (but, why is affine necessary for ate computation?)
-    ECP_BN254_affine(g1_point);
-    ECP2_BN254_affine(g2_point);
-
     PAIR_BN254_ate(pairing_out, g2_point, g1_point);
     PAIR_BN254_fexp(pairing_out);
 }

--- a/src/credential_BN254.c
+++ b/src/credential_BN254.c
@@ -84,9 +84,9 @@ int ecdaa_credential_BN254_generate(struct ecdaa_credential_BN254 *cred,
     ECP_BN254_mul(&Qxyl, xyl);
 
     // 9) Add Ax and xyl*Q and save to cred->C (C = x*A + xyl*Q)
+    //      Nb. Add doesn't convert to affine, so do that explicitly
     ECP_BN254_add(&cred->C, &Qxyl);
-    // Nb. No need to call ECP_BN254_affine here,
-    // as C always gets multiplied during signing (which implicitly converts to affine)
+    ECP_BN254_affine(&cred->C);
 
     // 10) Perform a Schnorr-like signature,
     //  to prove the credential was properly constructed by someone with knowledge of y.
@@ -144,9 +144,11 @@ int ecdaa_credential_BN254_validate(struct ecdaa_credential_BN254 *credential,
         ret = -1;
 
     // 4) Compute A+D
+    //      Nb. Add doesn't convert to affine, so do that explicitly
     ECP_BN254 AD;
     ECP_BN254_copy(&AD, &credential->A);
     ECP_BN254_add(&AD, &credential->D);
+    ECP_BN254_affine(&AD);
 
     // 5) Check e(C, P_2) == e(A+D, X)
     FP12_BN254 pairing_two;

--- a/src/internal/schnorr.c
+++ b/src/internal/schnorr.c
@@ -233,7 +233,7 @@ int credential_schnorr_verify(BIG_256_56 c,
     // 7) Compute difference of R2 and c*D, and save to R2 (R2 = s*member_public_key - c*D)
     ECP_BN254_sub(&R2, &D_c);
     // Nb. No need to call ECP_BN254_affine here,
-    // as R1 gets passed to ECP_BN254_toOctet in a minute (which implicitly converts to affine)
+    // as R2 gets passed to ECP_BN254_toOctet in a minute (which implicitly converts to affine)
 
     // 8) Compute c' = Hash( R1 | R2 | generator | B | member_public_key | D )
     //      (modular-reduce c', too).
@@ -352,7 +352,7 @@ int issuer_schnorr_verify(BIG_256_56 c,
     // 7) Compute difference of R2 and c*Y, and save to R2 (R2 = sy*P2 - c*Y)
     ECP2_BN254_sub(&R2, &Y_c);
     // Nb. No need to call ECP2_BN254_affine here,
-    // as R1 gets passed to ECP2_BN254_toOctet in a minute (which implicitly converts to affine)
+    // as R2 gets passed to ECP2_BN254_toOctet in a minute (which implicitly converts to affine)
 
     // 8) Compute c' = Hash( R1 | R2 | generator_2 | X | Y )
     //      (modular-reduce c', too).

--- a/src/signature_BN254.c
+++ b/src/signature_BN254.c
@@ -123,9 +123,11 @@ int ecdaa_signature_BN254_verify(struct ecdaa_signature_BN254 *signature,
         ret = -1;
 
     // 4) Compute R+W
+    //      Nb. Add doesn't convert to affine, so do that explicitly
     ECP_BN254 RW;
     ECP_BN254_copy(&RW, &signature->R);
     ECP_BN254_add(&RW, &signature->W);
+    ECP_BN254_affine(&RW);
 
     // 5) Check e(T, P_2) == e(R+W, X)
     FP12_BN254 pairing_two;


### PR DESCRIPTION
Only convert points to affine form when necessary (after calls to `_add` or `_sub`), and not every time a pairing is computed.

resolves #8 