### PR TITLE
Update all "length" functions to use void parameters.

### DIFF
--- a/include/ecdaa/issuer_keypair_BN254.h
+++ b/include/ecdaa/issuer_keypair_BN254.h
@@ -51,7 +51,7 @@ struct ecdaa_issuer_secret_key_BN254 {
 };
 
 #define ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH (2*MODBYTES_256_56)
-size_t ecdaa_issuer_secret_key_BN254_length();
+size_t ecdaa_issuer_secret_key_BN254_length(void);
 
 /*
  * Generate a fresh `ecdaa_issuer_public_key_BN254`, `ecdaa_issuer_secret_key_BN254` keypair.

--- a/include/ecdaa/member_keypair_BN254.h
+++ b/include/ecdaa/member_keypair_BN254.h
@@ -39,7 +39,7 @@ struct ecdaa_member_public_key_BN254 {
 };
 
 #define ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH ((2*MODBYTES_256_56 + 1) + MODBYTES_256_56 + MODBYTES_256_56)
-size_t ecdaa_member_public_key_BN254_length();
+size_t ecdaa_member_public_key_BN254_length(void);
 
 /*
  * Member's secret key.
@@ -49,7 +49,7 @@ struct ecdaa_member_secret_key_BN254 {
 };
 
 #define ECDAA_MEMBER_SECRET_KEY_BN254_LENGTH (MODBYTES_256_56)
-size_t ecdaa_member_secret_key_BN254_length();
+size_t ecdaa_member_secret_key_BN254_length(void);
 
 /*
  * Generate a fresh `ecdaa_member_public_key_BN254`, `ecdaa_member_secret_key_BN254` pair.

--- a/include/ecdaa/signature_BN254.h
+++ b/include/ecdaa/signature_BN254.h
@@ -45,7 +45,7 @@ struct ecdaa_signature_BN254 {
 };
 
 #define ECDAA_SIGNATURE_BN254_LENGTH (2*MODBYTES_256_56 + 4*(2*MODBYTES_256_56 + 1))
-size_t ecdaa_signature_BN254_length();
+size_t ecdaa_signature_BN254_length(void);
 /*
  * Create an ECDAA signature.
  *

--- a/src/amcl-extensions/ecp2_BN254.c
+++ b/src/amcl-extensions/ecp2_BN254.c
@@ -18,7 +18,7 @@
 
 #include "./ecp2_BN254.h"
 
-size_t ecp2_BN254_length()
+size_t ecp2_BN254_length(void)
 {
     return ECP2_BN254_LENGTH;
 }

--- a/src/amcl-extensions/ecp2_BN254.h
+++ b/src/amcl-extensions/ecp2_BN254.h
@@ -29,7 +29,7 @@ extern "C" {
 #include <stddef.h>
 
 #define ECP2_BN254_LENGTH (4*MODBYTES_256_56 + 1)
-size_t ecp2_BN254_length();
+size_t ecp2_BN254_length(void);
 
 /*
  * Initialize ECP2_BN254 point to G2 generator.

--- a/src/amcl-extensions/ecp_BN254.c
+++ b/src/amcl-extensions/ecp_BN254.c
@@ -18,7 +18,7 @@
 
 #include "./ecp_BN254.h"
 
-size_t ecp_BN254_length()
+size_t ecp_BN254_length(void)
 {
     return ECP_BN254_LENGTH;
 }

--- a/src/amcl-extensions/ecp_BN254.h
+++ b/src/amcl-extensions/ecp_BN254.h
@@ -30,7 +30,7 @@ extern "C" {
 #include <stdint.h>
 
 #define ECP_BN254_LENGTH (2*MODBYTES_256_56 + 1)
-size_t ecp_BN254_length();
+size_t ecp_BN254_length(void);
 
 /*
  * Initialize ECP_BN254 point to G1 generator.

--- a/src/credential_BN254.c
+++ b/src/credential_BN254.c
@@ -29,12 +29,12 @@
 #include <ecdaa/issuer_keypair_BN254.h>
 #include <ecdaa/group_public_key_BN254.h>
 
-size_t serialized_credential_BN254_length()
+size_t ecdaa_credential_BN254_length(void)
 {
     return ECDAA_CREDENTIAL_BN254_LENGTH;
 }
 
-size_t serialized_credential_BN254_signature_length()
+size_t ecdaa_credential_BN254_signature_length(void)
 {
     return ECDAA_CREDENTIAL_BN254_SIGNATURE_LENGTH;
 }

--- a/src/issuer_keypair_BN254.c
+++ b/src/issuer_keypair_BN254.c
@@ -28,7 +28,7 @@ size_t ecdaa_issuer_public_key_BN254_length(void) {
     return ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH;
 }
 
-size_t ecdaa_issuer_secret_key_BN254_length() {
+size_t ecdaa_issuer_secret_key_BN254_length(void) {
     return ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH;
 }
 

--- a/src/member_keypair_BN254.c
+++ b/src/member_keypair_BN254.c
@@ -23,12 +23,12 @@
 
 #include <assert.h>
 
-size_t ecdaa_member_public_key_BN254_length()
+size_t ecdaa_member_public_key_BN254_length(void)
 {
    return ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH;
 }
 
-size_t ecdaa_member_secret_key_BN254_length()
+size_t ecdaa_member_secret_key_BN254_length(void)
 {
     return ECDAA_MEMBER_SECRET_KEY_BN254_LENGTH;
 }

--- a/src/signature_BN254.c
+++ b/src/signature_BN254.c
@@ -32,7 +32,7 @@
 #include <amcl/pair_BN254.h>
 #include <amcl/fp12_BN254.h>
 
-size_t ecdaa_signature_BN254_length()
+size_t ecdaa_signature_BN254_length(void)
 {
     return ECDAA_SIGNATURE_BN254_LENGTH;
 }


### PR DESCRIPTION
This is pedantic, but function declarations for functions that take no parameters should be `(void)`, not just `()` (as in C++).