### PR TITLE
Improve serialization for member public key and credential

### DIFF
--- a/include/ecdaa/credential_BN254.h
+++ b/include/ecdaa/credential_BN254.h
@@ -130,7 +130,8 @@ void ecdaa_credential_BN254_signature_serialize(uint8_t *buffer_out,
 int ecdaa_credential_BN254_deserialize_with_signature(struct ecdaa_credential_BN254 *credential_out,
                                                       struct ecdaa_member_public_key_BN254 *member_pk,
                                                       struct ecdaa_group_public_key_BN254 *gpk,
-                                                      uint8_t *buffer_in);
+                                                      uint8_t *cred_buffer_in,
+                                                      uint8_t *cred_sig_buffer_in);
 
 /*
  * De-serialize an `ecdaa_credential_BN254`, check its validity (signature _not_ checked).

--- a/include/ecdaa/member_keypair_BN254.h
+++ b/include/ecdaa/member_keypair_BN254.h
@@ -110,6 +110,23 @@ int ecdaa_member_public_key_BN254_deserialize(struct ecdaa_member_public_key_BN2
                                               uint32_t nonce_length);
 
 /*
+ * De-serialize an `ecdaa_member_public_key_BN254`, check its validity, but NOT its signature.
+ *
+ * The serialized format is expected to be:
+ *  ( 0x04 | Q.x-coord | Q.y-coord | c | s )
+ *  where all numbers are zero-padded and in big-endian byte-order.
+ *
+ *  NOTE: The full public key (including the signature) is de-serialized,
+ *  even though the signature does NOT get checked.
+ *
+ * Returns:
+ * 0 on success
+ * -1 if the format is incorrect
+ */
+int ecdaa_member_public_key_BN254_deserialize_no_check(struct ecdaa_member_public_key_BN254 *pk_out,
+                                                       uint8_t *buffer_in);
+
+/*
  * Serialize an `ecdaa_member_secret_key_BN254`
  *
  * The serialized secret key is zero-padded in big-endian byte-order.

--- a/src/credential_BN254.c
+++ b/src/credential_BN254.c
@@ -181,17 +181,18 @@ void ecdaa_credential_BN254_signature_serialize(uint8_t *buffer_out,
 int ecdaa_credential_BN254_deserialize_with_signature(struct ecdaa_credential_BN254 *credential_out,
                                                       struct ecdaa_member_public_key_BN254 *member_pk,
                                                       struct ecdaa_group_public_key_BN254 *gpk,
-                                                      uint8_t *buffer_in)
+                                                      uint8_t *cred_buffer_in,
+                                                      uint8_t *cred_sig_buffer_in)
 {
     int ret = 0;
 
     // 1) De-serialize the credential
-    ret = ecdaa_credential_BN254_deserialize(credential_out, buffer_in);
+    ret = ecdaa_credential_BN254_deserialize(credential_out, cred_buffer_in);
 
     // 2) De-serialize the credential signature
     struct ecdaa_credential_BN254_signature cred_sig;
-    BIG_256_56_fromBytes(cred_sig.c, (char*)(buffer_in + 4*ECP_BN254_LENGTH));
-    BIG_256_56_fromBytes(cred_sig.c, (char*)(buffer_in + 4*ECP_BN254_LENGTH + MODBYTES_256_56));
+    BIG_256_56_fromBytes(cred_sig.c, (char*)(cred_sig_buffer_in));
+    BIG_256_56_fromBytes(cred_sig.s, (char*)(cred_sig_buffer_in + MODBYTES_256_56));
 
     if (0 == ret) {
         int valid_ret = ecdaa_credential_BN254_validate(credential_out, &cred_sig, member_pk, gpk);

--- a/src/member_keypair_BN254.c
+++ b/src/member_keypair_BN254.c
@@ -94,14 +94,10 @@ int ecdaa_member_public_key_BN254_deserialize(struct ecdaa_member_public_key_BN2
 {
     int ret = 0;
 
-    // 1) Deserialize schnorr public key Q.
-    int deserial_ret = ecp_BN254_deserialize(&pk_out->Q, buffer_in);
+    // 1) Deserialize public key and its signature.
+    int deserial_ret = ecdaa_member_public_key_BN254_deserialize_no_check(pk_out, buffer_in);
     if (0 != deserial_ret)
         ret = -1;
-
-    // 2) Deserialize the schnorr signature
-    BIG_256_56_fromBytes(pk_out->c, (char*)(buffer_in + ecp_BN254_length()));
-    BIG_256_56_fromBytes(pk_out->s, (char*)(buffer_in + ecp_BN254_length() + MODBYTES_256_56));
 
     if (0 == deserial_ret) {
         // 3) Verify the schnorr signature.
@@ -110,6 +106,23 @@ int ecdaa_member_public_key_BN254_deserialize(struct ecdaa_member_public_key_BN2
         if (0 != schnorr_ret)
             ret = -2;
     }
+
+    return ret;
+}
+
+int ecdaa_member_public_key_BN254_deserialize_no_check(struct ecdaa_member_public_key_BN254 *pk_out,
+                                                       uint8_t *buffer_in)
+{
+    int ret = 0;
+
+    // 1) Deserialize schnorr public key Q.
+    int deserial_ret = ecp_BN254_deserialize(&pk_out->Q, buffer_in);
+    if (0 != deserial_ret)
+        ret = -1;
+
+    // 2) Deserialize the schnorr signature
+    BIG_256_56_fromBytes(pk_out->c, (char*)(buffer_in + ecp_BN254_length()));
+    BIG_256_56_fromBytes(pk_out->s, (char*)(buffer_in + ecp_BN254_length() + MODBYTES_256_56));
 
     return ret;
 }


### PR DESCRIPTION
- Fix credential deserialization.
- Allow two buffers (one for the credential, one for the credential_signature) for the`ecdaa_credential_BN254_deserialize_with_signature` function.
- Allow non-checking deserializer for member public key (so member itself can deserialize)