### PR TITLE
Do membership checks in deserialization code, only.

### DIFF
--- a/src/amcl-extensions/ecp2_BN254.c
+++ b/src/amcl-extensions/ecp2_BN254.c
@@ -39,36 +39,6 @@ void ecp2_BN254_set_to_generator(ECP2_BN254 *point)
     ECP2_BN254_set(point, &x, &y);
 }
 
-int ecp2_BN254_check_membership(ECP2_BN254 *point)
-{
-    // TODO: Check if this is correct!
-    ECP2_BN254 point_copy;
-    ECP2_BN254_copy(&point_copy, point);
-
-    BIG_256_56 curve_order;
-    BIG_256_56_rcopy(curve_order, CURVE_Order_BN254);
-
-    /* Check point is not in wrong group */
-    int nb = BIG_256_56_nbits(curve_order);
-    BIG_256_56 k;
-    BIG_256_56_one(k);
-    BIG_256_56_shl(k, (nb+4)/2);
-    BIG_256_56_add(k, curve_order, k);
-    BIG_256_56_sdiv(k, curve_order); /* get co-factor */
-
-    while (BIG_256_56_parity(k) == 0) {
-        ECP2_BN254_dbl(&point_copy);
-        BIG_256_56_fshr(k,1);
-    }
-
-    if (!BIG_256_56_isunity(k))
-        ECP2_BN254_mul(&point_copy,k);
-    if (ECP2_BN254_isinf(&point_copy))
-        return -1;
-
-    return 0;
-}
-
 void ecp2_BN254_serialize(uint8_t *buffer_out,
                          ECP2_BN254 *point)
 {
@@ -82,20 +52,50 @@ void ecp2_BN254_serialize(uint8_t *buffer_out,
 }
 
 int ecp2_BN254_deserialize(ECP2_BN254 *point_out,
-                           const uint8_t *buffer)
+                           uint8_t *buffer)
 {
-    int ret = 0;
+    // 1) Check that serialized point was properly formatted.
+    if (0x4 != buffer[0])
+        return -2;
 
-    if (0x04 != buffer[0])
-        ret = -1;
+    // 2) Get the xa, xb, ya, yb coordinates.
+	BIG_256_56 xa, xb, ya, yb;
+    BIG_256_56_fromBytes(xa, (char*)&(buffer[1]));
+    BIG_256_56_fromBytes(xb, (char*)&(buffer[MODBYTES_256_56+1]));
+    BIG_256_56_fromBytes(ya, (char*)&(buffer[2*MODBYTES_256_56+1]));
+    BIG_256_56_fromBytes(yb, (char*)&(buffer[3*MODBYTES_256_56+1]));
 
-    octet as_oct = {.len = 0,
-                    .max = ECP2_BN254_LENGTH,
-                    .val = (char*)(buffer + 1)};
+    // 3) Check the coordinates are valid Fp points
+    //  (i.e. that they are less-than modulus)
+    //  (step 2 in X9.62 Sec 5.2.2)
+    BIG_256_56 q;
+    BIG_256_56_rcopy(q, Modulus_BN254);
+    if (1 == BIG_256_56_comp(xa, q))
+        return -1;
+    if (1 == BIG_256_56_comp(xb, q))
+        return -1;
+    if (1 == BIG_256_56_comp(ya, q))
+        return -1;
+    if (1 == BIG_256_56_comp(yb, q))
+        return -1;
 
-    int from_ret = ECP2_BN254_fromOctet(point_out, &as_oct);
-    if (1 != from_ret)
-        ret = -1;
+    // 4) Check that point is on curve (ECP2_BN254_set does this implicitly).
+    //      (step 3 in X9.62 Sec 5.2.2)
+    FP2_BN254 wx, wy;
+    FP_BN254_nres(&(wx.a), xa);
+    FP_BN254_nres(&(wx.b), xb);
+    FP_BN254_nres(&(wy.a), ya);
+    FP_BN254_nres(&(wy.b), yb);
+    if (!ECP2_BN254_set(point_out, &wx, &wy))
+        return -1;
 
-    return ret;
+    // 5) Check that point is not the identity.
+    //      (step 1 in X9.62 Sec 5.2.2)
+    if (ECP2_BN254_isinf(point_out)) {
+        return -1;
+    }
+
+    // TODO: How to check for subgroup attack? How get cofactor of G2?
+
+    return 0;
 }

--- a/src/amcl-extensions/ecp2_BN254.h
+++ b/src/amcl-extensions/ecp2_BN254.h
@@ -37,18 +37,9 @@ size_t ecp2_BN254_length(void);
 void ecp2_BN254_set_to_generator(ECP2_BN254 *point);
 
 /*
- * Check if the given ECP2_BN254 point is a member of G2.
- *
- * Returns:
- * 0 on success
- * -1 if the point is _not_ in G2
- */
-int ecp2_BN254_check_membership(ECP2_BN254 *point);
-
-/*
  * Serialize an ECP2_BN254 point.
  *
- * Format: ( 0x04 | x-coordinate | y-coordinate )
+ * Format: ( 0x04 | x-coordinate-real-part | x-coordinate-imaginary-part | y-coordinate-real-part | y-coordinate-imaginary-part )
  */
 void ecp2_BN254_serialize(uint8_t *buffer_out,
                          ECP2_BN254 *point);
@@ -63,7 +54,7 @@ void ecp2_BN254_serialize(uint8_t *buffer_out,
  * -1 if the point is not on the curve
  */
 int ecp2_BN254_deserialize(ECP2_BN254 *point_out,
-                           const uint8_t *buffer);
+                           uint8_t *buffer);
 
 #ifdef __cplusplus
 }

--- a/src/amcl-extensions/ecp_BN254.h
+++ b/src/amcl-extensions/ecp_BN254.h
@@ -38,15 +38,6 @@ size_t ecp_BN254_length(void);
 void ecp_BN254_set_to_generator(ECP_BN254 *point);
 
 /*
- * Check if the given ECP_BN254 point is a member of G1.
- *
- * Returns:
- * 0 on success
- * -1 if the point is _not_ in G1
- */
-int ecp_BN254_check_membership(ECP_BN254 *point);
-
-/*
  * Serialize an ECP_BN254 point.
  *
  * Format: ( 0x04 | x-coordinate | y-coordinate )
@@ -64,7 +55,7 @@ void ecp_BN254_serialize(uint8_t *buffer_out,
  * -1 if the point is not on the curve
  */
 int ecp_BN254_deserialize(ECP_BN254 *point_out,
-                          const uint8_t *buffer);
+                          uint8_t *buffer);
 
 #ifdef __cplusplus
 }

--- a/src/credential_BN254.c
+++ b/src/credential_BN254.c
@@ -116,13 +116,8 @@ int ecdaa_credential_BN254_validate(struct ecdaa_credential_BN254 *credential,
     int ret = 0;
 
     // 1) Check A,B,C,D for membership in group, and A for !=inf
-    if (0 != ecp_BN254_check_membership(&credential->A)
-            || 0 != ecp_BN254_check_membership(&credential->B)
-            || 0 != ecp_BN254_check_membership(&credential->C)
-            || 0 != ecp_BN254_check_membership(&credential->D))
-        ret = -1;
-    if (ECP_BN254_isinf(&credential->A))
-        ret = -1;
+    // NOTE: We assume the credential was obtained from a call to `deserialize`,
+    //  which already checked the validity of the points A,B,C,D
     
     // 2) Verify schnorr-like signature
     int schnorr_ret = credential_schnorr_verify(credential_signature->c,

--- a/src/group_public_key_BN254.c
+++ b/src/group_public_key_BN254.c
@@ -37,25 +37,11 @@ int ecdaa_group_public_key_BN254_deserialize(struct ecdaa_group_public_key_BN254
 {
     int ret = 0;
 
-    int deserial_ret_x = ecp2_BN254_deserialize(&gpk_out->X, buffer_in);
-    if (0 != deserial_ret_x)
+    if (0 != ecp2_BN254_deserialize(&gpk_out->X, buffer_in))
         ret = -1;
 
-    if (0 == deserial_ret_x) {
-        int member_ret_x = ecp2_BN254_check_membership(&gpk_out->X);
-        if (0 != member_ret_x)
-            ret = -2;
-    }
-
-    int deserial_ret_y = ecp2_BN254_deserialize(&gpk_out->Y, buffer_in + ECP2_BN254_LENGTH);
-    if (0 != deserial_ret_y)
+    if (0 != ecp2_BN254_deserialize(&gpk_out->Y, buffer_in + ECP2_BN254_LENGTH))
         ret = -1;
-
-    if (0 == deserial_ret_y) {
-        int member_ret_y = ecp2_BN254_check_membership(&gpk_out->Y);
-        if (0 != member_ret_y)
-            ret = -2;
-    }
 
     return ret;
 }

--- a/src/internal/schnorr.c
+++ b/src/internal/schnorr.c
@@ -51,8 +51,8 @@ int schnorr_sign(BIG_256_56 *c_out,
                  struct ecdaa_prng *prng)
 {
     // 1) (Commit 1) Verify basepoint belongs to group
-    if (0 != ecp_BN254_check_membership(basepoint))
-        return -1;
+    // NOTE: We assume the basepoint was obtained from a call to set_to_generator,
+    //  which means it's valid.
 
     // 2) (Commit 2) Choose random k <- Z_n
     BIG_256_56 k;
@@ -92,8 +92,8 @@ int schnorr_verify(BIG_256_56 c,
     int ret = 0;
 
     // 1) Check public key for validity
-    if (0 != ecp_BN254_check_membership(public_key))
-        ret = -1;
+    // NOTE: We assume the public key was obtained from `deserialize`,
+    //  which checked its validity.
 
     // 2) Multiply basepoint by s (R = s*P)
     ECP_BN254 R;

--- a/src/signature_BN254.c
+++ b/src/signature_BN254.c
@@ -94,13 +94,8 @@ int ecdaa_signature_BN254_verify(struct ecdaa_signature_BN254 *signature,
     int ret = 0;
 
     // 1) Check R,S,T,W for membership in group, and R and S for !=inf
-    if (0 != ecp_BN254_check_membership(&signature->R)
-            || 0 != ecp_BN254_check_membership(&signature->S)
-            || 0 != ecp_BN254_check_membership(&signature->T)
-            || 0 != ecp_BN254_check_membership(&signature->W))
-        ret = -1;
-    if (ECP_BN254_isinf(&signature->R) || ECP_BN254_isinf(&signature->S))
-        ret = -1;
+    // NOTE: We assume the signature was obtained from a call to `deserialize`,
+    //  which already checked the validity of the points R,S,T,W
     
     // 2) Check Schnorr-type signature
     int schnorr_ret = schnorr_verify(signature->c,

--- a/test/member_keypair-tests.c
+++ b/test/member_keypair-tests.c
@@ -72,8 +72,6 @@ void member_public_is_valid()
     uint8_t nonce[32] = {0};
     ecdaa_member_key_pair_BN254_generate(&pk, &sk, nonce, sizeof(nonce), &prng);
 
-    TEST_ASSERT(0 == ecp_BN254_check_membership(&pk.Q));
-
     ecdaa_prng_free(&prng);
 
     printf("\tsuccess\n");


### PR DESCRIPTION
Only check that a point is valid (do the X9.62 checks, for being on the curve, in the correct subgroup, etc) during serialization. Don't repeat them elsewhere, and instead just assume that a point given to, for example, schnorr_verify was obtained via a deserialization and thus is already checked validity.

Also, we no longer do the subgroup-membership check for G2 points. This is because I'm not sure that the technique that had been used before (which was copied from G1 code) is appropriate for this group.

Related to #7 
However, we keep that issue open, because the necessity of doing the checks in G2 and exactly how to do the G2 checks remains open.