### PR TITLE
Use coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
 
   # Debug build, to get code coverage with gcov
   - env: TYPE=DEBUG_WITH_COVERAGE
+    before_install:
+      - pip install --user cpp-coveralls
     before_script:
       - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
       - cmake . -DCMAKE_BUILD_TYPE=DebugWithCoverage -DCMAKE_C_OUTPUT_EXTENSION_REPLACE=ON
@@ -44,7 +46,7 @@ jobs:
       - cmake --build . -- -j2
       - ctest -VV
     after_success:
-      - .travis/upload-gcov-results.sh ${TRAVIS_BUILD_DIR}
+      - coveralls --exclude examples --exclude amcl --exclude ${LIBSODIUM_DIR}
 
   # Release build, clang
   - env: TYPE=RELEASE-WITH-CLANG

--- a/.travis/install-libsodium.sh
+++ b/.travis/install-libsodium.sh
@@ -20,6 +20,8 @@ fi
 
 version=1.0.13
 install_dir="$1"
+mkdir -p ${install_dir}
+cd ${install_dir}
 wget https://download.libsodium.org/libsodium/releases/libsodium-${version}.tar.gz
 tar xvfz libsodium-${version}.tar.gz
 cd libsodium-${version}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The project is self-contained, and provides all DAA functionality for Issuers, M
 # Project Status
 
 [![Build Status](https://travis-ci.org/xaptum/ecdaa.svg?branch=master)](https://travis-ci.org/xaptum/ecdaa)
-[![codecov](https://codecov.io/gh/xaptum/ecdaa/branch/master/graph/badge.svg)](https://codecov.io/gh/xaptum/ecdaa)
+[![Coverage Status](https://coveralls.io/repos/github/xaptum/ecdaa/badge.svg?branch=master)](https://coveralls.io/github/xaptum/ecdaa?branch=master)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/13775/badge.svg)](https://scan.coverity.com/projects/xaptum-ecdaa)
 
 # Requirements
@@ -188,7 +188,7 @@ verify message-text sig.bin gpk.bin sk_revocation_list.bin num-sks-in-sk_revocat
 # Testing and Analysis
 
 The unit-tests are contained in the `test` directory.
-Test code coverage is measured using `gcov`, and monitored via `codecov`.
+Test code coverage is measured using `gcov`, and monitored via `coveralls`.
 
 ## Valgrind
 


### PR DESCRIPTION
Replace Codecov with Coveralls.

This was done because most of our source code will be generated from template files.

While both tools rely on github to get our source code, and thus can't show us the coverage for the generated files (they're not checked in to git), Coveralls will still include the generated files in the reports.