### PR TITLE
Use `enable=all` in cppcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,11 @@ jobs:
       apt:
         packages:
           - cppcheck
+    before_script:
+      - .travis/install-libsodium.sh ${LIBSODIUM_DIR}
+      - cmake . -DCMAKE_BUILD_TYPE=Release
     script:
+      - cmake --build . -- -j2
       - .travis/run-cppcheck.sh
 
   # Memcheck

--- a/.travis/run-cppcheck.sh
+++ b/.travis/run-cppcheck.sh
@@ -14,14 +14,13 @@
 #    limitations under the License
 
 if [[ $# -eq 0 ]]; then
-        toplevel_dir="`pwd`"
+        generated_sources_dir="`pwd`"
 elif [[ $# -eq 1 ]]; then
-        toplevel_dir="$1"
+        generated_sources_dir="$1"
 else
         echo "usage: $0 <path-to-toplevel-directory>"
         exit 1
 fi
 
 # "error-exitcode" makes bugs cause non-zero return code
-# TODO: Add enable=all once we have tests using _all_ functions
-cppcheck -v --std=c99 --error-exitcode=6 ${toplevel_dir}/include/ ${toplevel_dir}/src/ ${toplevel_dir}/test/
+cppcheck -v --std=c99 --error-exitcode=6 --enable=all --suppress=missingIncludeSystem -I ${generated_sources_dir}/include/ -I ${generated_sources_dir} ${generated_sources_dir}/src/ ${generated_sources_dir}/test/ ${generated_sources_dir}/examples/

--- a/.travis/run-cppcheck.sh
+++ b/.travis/run-cppcheck.sh
@@ -23,4 +23,4 @@ else
 fi
 
 # "error-exitcode" makes bugs cause non-zero return code
-cppcheck -v --std=c99 --error-exitcode=6 --enable=all --suppress=missingIncludeSystem -I ${generated_sources_dir}/include/ -I ${generated_sources_dir} ${generated_sources_dir}/src/ ${generated_sources_dir}/test/ ${generated_sources_dir}/examples/
+cppcheck -v --std=c99 --error-exitcode=6 --enable=all --suppress=missingIncludeSystem -I ${generated_sources_dir}/include/ -I ${generated_sources_dir} ${generated_sources_dir}/src/ ${generated_sources_dir}/test/ ${generated_sources_dir}/examples/ --suppress=purgedConfiguration

--- a/README.md
+++ b/README.md
@@ -242,14 +242,11 @@ The `cppcheck` static analyzer is also available, and is run every build on `tra
 To run it do the following:
 
 ```bash
-cppcheck -v --std=c99 --error-exitcode=6 include/ src/ test/
+cppcheck --enable=all -v --std=c99 --error-exitcode=6 include/ src/ test/
 ```
 
 This tool is generally considered to have a lower false-positive rate than
 many other static analyzers, though with that comes a potential loss of strictness.
-
-TODO: Once we have tests that actually use all the defined functions, we should
-use `enable=all` in `cppcheck`.
 
 ## Address and Undefined Behavior Sanitizers
 

--- a/test/benchmarks_ZZZ.c
+++ b/test/benchmarks_ZZZ.c
@@ -98,7 +98,7 @@ void schnorr_sign_benchmark()
 {
     unsigned rounds = 2500;
 
-    printf("Starting schnorr::schnorr_sign_benchmark (%d iterations)...\n", rounds);
+    printf("Starting schnorr::schnorr_sign_benchmark (%u iterations)...\n", rounds);
 
     ECP_ZZZ public;
     BIG_XXX private;
@@ -139,7 +139,7 @@ static void sign_benchmark()
 {
     unsigned rounds = 250;
 
-    printf("Starting sign-and-verify::sign_benchmark (%d iterations)...\n", rounds);
+    printf("Starting sign-and-verify::sign_benchmark (%u iterations)...\n", rounds);
 
     sign_and_verify_fixture fixture;
     setup(&fixture);
@@ -169,7 +169,7 @@ static void verify_benchmark()
 {
     unsigned rounds = 250;
 
-    printf("Starting sign-and-verify::verify_benchmark (%d iterations)...\n", rounds);
+    printf("Starting sign-and-verify::verify_benchmark (%u iterations)...\n", rounds);
 
     sign_and_verify_fixture fixture;
     setup(&fixture);


### PR DESCRIPTION
This performs a much more thorough static analysis of our code.

This PR also updates the way we're using cppcheck, to reflect the recent change to generated source code.

As a result of both of these, the cppcheck check takes ~5x longer than it used to.