### PR TITLE
Integration test script uses Python3 and xrange, which is inconsistent.

### DIFF
--- a/test/integration-tests.py
+++ b/test/integration-tests.py
@@ -38,7 +38,7 @@ class Issuer(object):
         self.sk_rev_list = []
 
     def GetNonce(self, pk_file):
-        nonce = ''.join([random.choice(string.lowercase) for i in xrange(32)])
+        nonce = ''.join([random.choice(string.lowercase) for i in range(32)])
         self.nonces[nonce] = pk_file
         return nonce
 


### PR DESCRIPTION
The integration script uses xrange, which is only available in Python2.
However, the script has a she-bang saying it's python3.
We didn't see this when runing tests,
because our CTest actually runs it as Python2.

To be consistent, turn xrange into range,
and run the script as Python3.