### PR TITLE
Read msg from file

### DIFF
--- a/examples/extract_group_public_key.c
+++ b/examples/extract_group_public_key.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 
     // Read issuer public key from disk.
     struct ecdaa_issuer_public_key_BN254 ipk;
-    if (0 != read_file_into_buffer(buffer, ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH, args.issuer_public_key_file)) {
+    if (ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH != read_file_into_buffer(buffer, ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH, args.issuer_public_key_file)) {
         fprintf(stderr, "Error reading issuer public key file: \"%s\"\n", args.issuer_public_key_file);
         return 1;
     }
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 
     // Write group-public-key to file
     ecdaa_group_public_key_BN254_serialize(buffer, &ipk.gpk);
-    if (0 != write_buffer_to_file(args.group_public_key_file, buffer, ECDAA_GROUP_PUBLIC_KEY_BN254_LENGTH)) {
+    if (ECDAA_GROUP_PUBLIC_KEY_BN254_LENGTH != write_buffer_to_file(args.group_public_key_file, buffer, ECDAA_GROUP_PUBLIC_KEY_BN254_LENGTH)) {
         fprintf(stderr, "Error writing group public key to file: \"%s\"\n", args.group_public_key_file);
         return 1;
     }

--- a/examples/file_utils.h
+++ b/examples/file_utils.h
@@ -30,10 +30,7 @@ static int read_file_into_buffer(uint8_t *buffer, size_t bytes_to_read, const ch
 
     (void)fclose(ptr);
 
-    if (bytes_read != bytes_to_read)
-        return -1;
-
-    return 0;
+    return (int)bytes_read;
 }
 
 static int write_buffer_to_file(const char *filename, uint8_t *buffer, size_t bytes_to_write)
@@ -48,8 +45,6 @@ static int write_buffer_to_file(const char *filename, uint8_t *buffer, size_t by
 
     (void)fclose(ptr);
 
-    if (bytes_written != bytes_to_write)
-        return -1;
 
-    return 0;
+    return (int)bytes_written;
 }

--- a/examples/issuer_create_group.c
+++ b/examples/issuer_create_group.c
@@ -60,14 +60,14 @@ int main(int argc, char *argv[])
 
     // Write public-key to file
     ecdaa_issuer_public_key_BN254_serialize(buffer, &ipk);
-    if (0 != write_buffer_to_file(args.public_key_file, buffer, ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH)) {
+    if (ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH != write_buffer_to_file(args.public_key_file, buffer, ECDAA_ISSUER_PUBLIC_KEY_BN254_LENGTH)) {
         fprintf(stderr, "Error writing public key to file: \"%s\"\n", args.public_key_file);
         return 1;
     }
 
     // Write secret-key to file
     ecdaa_issuer_secret_key_BN254_serialize(buffer, &isk);
-    if (0 != write_buffer_to_file(args.secret_key_file, buffer, ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH)) {
+    if (ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH != write_buffer_to_file(args.secret_key_file, buffer, ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH)) {
         fprintf(stderr, "Error writing secret key to file: \"%s\"\n", args.secret_key_file);
         return 1;
     }

--- a/examples/issuer_respond_to_join_request.c
+++ b/examples/issuer_respond_to_join_request.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
         return 1;
     }
     struct ecdaa_member_public_key_BN254 pk;
-    if (0 != read_file_into_buffer(buffer, ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH, args.member_public_key_file)) {
+    if (ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH != read_file_into_buffer(buffer, ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH, args.member_public_key_file)) {
         fprintf(stderr, "Error reading member public key file: \"%s\"\n", args.member_public_key_file);
         return 1;
     }
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 
     // Read issuer secret key from disk;
     struct ecdaa_issuer_secret_key_BN254 isk;
-    if (0 != read_file_into_buffer(buffer, ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH, args.issuer_secret_key_file)) {
+    if (ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH != read_file_into_buffer(buffer, ECDAA_ISSUER_SECRET_KEY_BN254_LENGTH, args.issuer_secret_key_file)) {
         fprintf(stderr, "Error reading issuer secret key file: \"%s\"\n", args.issuer_secret_key_file);
         return 1;
     }
@@ -98,14 +98,14 @@ int main(int argc, char *argv[])
 
     // Write credential to file
     ecdaa_credential_BN254_serialize(buffer, &cred);
-    if (0 != write_buffer_to_file(args.credential_out_file, buffer, ECDAA_CREDENTIAL_BN254_LENGTH)) {
+    if (ECDAA_CREDENTIAL_BN254_LENGTH != write_buffer_to_file(args.credential_out_file, buffer, ECDAA_CREDENTIAL_BN254_LENGTH)) {
         fprintf(stderr, "Error writing credential to file: \"%s\"\n", args.credential_out_file);
         return 1;
     }
 
     // Write credential signature to file
     ecdaa_credential_BN254_signature_serialize(buffer, &cred_sig);
-    if (0 != write_buffer_to_file(args.credential_signature_out_file, buffer, ECDAA_CREDENTIAL_BN254_SIGNATURE_LENGTH)) {
+    if (ECDAA_CREDENTIAL_BN254_SIGNATURE_LENGTH != write_buffer_to_file(args.credential_signature_out_file, buffer, ECDAA_CREDENTIAL_BN254_SIGNATURE_LENGTH)) {
         fprintf(stderr, "Error writing credential signature to file: \"%s\"\n", args.credential_signature_out_file);
         return 1;
     }

--- a/examples/member_process_join_response.c
+++ b/examples/member_process_join_response.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 
     // Read member public key from disk
     struct ecdaa_member_public_key_BN254 pk;
-    if (0 != read_file_into_buffer(buffer, ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH, args.member_public_key_file)) {
+    if (ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH != read_file_into_buffer(buffer, ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH, args.member_public_key_file)) {
         fprintf(stderr, "Error reading member public key file: \"%s\"\n", args.member_public_key_file);
         return 1;
     }
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 
     // Read group public key from disk
     struct ecdaa_group_public_key_BN254 gpk;
-    if (0 != read_file_into_buffer(buffer, ECDAA_GROUP_PUBLIC_KEY_BN254_LENGTH, args.group_public_key_file)) {
+    if (ECDAA_GROUP_PUBLIC_KEY_BN254_LENGTH != read_file_into_buffer(buffer, ECDAA_GROUP_PUBLIC_KEY_BN254_LENGTH, args.group_public_key_file)) {
         fprintf(stderr, "Error reading group public key file: \"%s\"\n", args.group_public_key_file);
         return 1;
     }
@@ -68,11 +68,11 @@ int main(int argc, char *argv[])
 
     // Read credential and credential signature from disk.
     struct ecdaa_credential_BN254 cred;
-    if (0 != read_file_into_buffer(buffer, ECDAA_CREDENTIAL_BN254_LENGTH, args.credential_file)) {
+    if (ECDAA_CREDENTIAL_BN254_LENGTH != read_file_into_buffer(buffer, ECDAA_CREDENTIAL_BN254_LENGTH, args.credential_file)) {
         fprintf(stderr, "Error reading credential file: \"%s\"\n", args.credential_file);
         return 1;
     }
-    if (0 != read_file_into_buffer(buffer + ECDAA_CREDENTIAL_BN254_LENGTH,
+    if (ECDAA_CREDENTIAL_BN254_SIGNATURE_LENGTH != read_file_into_buffer(buffer + ECDAA_CREDENTIAL_BN254_LENGTH,
                                    ECDAA_CREDENTIAL_BN254_SIGNATURE_LENGTH,
                                    args.credential_signature_file)) {
         fprintf(stderr, "Error reading credential signature file: \"%s\"\n", args.credential_signature_file);

--- a/examples/member_request_join.c
+++ b/examples/member_request_join.c
@@ -65,14 +65,14 @@ int main(int argc, char *argv[])
 
     // Write public key to file
     ecdaa_member_public_key_BN254_serialize(buffer, &pk);
-    if (0 != write_buffer_to_file(args.public_key_file, buffer, ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH)) {
+    if (ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH != write_buffer_to_file(args.public_key_file, buffer, ECDAA_MEMBER_PUBLIC_KEY_BN254_LENGTH)) {
         fprintf(stderr, "Error writing public key to file: \"%s\"\n", args.public_key_file);
         return 1;
     }
 
     // Write secret key to file
     ecdaa_member_secret_key_BN254_serialize(buffer, &sk);
-    if (0 != write_buffer_to_file(args.secret_key_file, buffer, ECDAA_MEMBER_SECRET_KEY_BN254_LENGTH)) {
+    if (ECDAA_MEMBER_SECRET_KEY_BN254_LENGTH != write_buffer_to_file(args.secret_key_file, buffer, ECDAA_MEMBER_SECRET_KEY_BN254_LENGTH)) {
         fprintf(stderr, "Error writing secret key to file: \"%s\"\n", args.secret_key_file);
         return 1;
     }

--- a/test/integration-tests.py
+++ b/test/integration-tests.py
@@ -103,15 +103,21 @@ class Member(object):
             exit(1)
 
     def Sign(self, message, sig_file):
-        if 0 != subprocess.call([examples_dir + 'member_sign', self.sk_file, self.cred_file, sig_file, message]):
+        message_filename = examples_dir + '/msg_sign.tmp.bin'
+        with open(message_filename, 'w') as message_file:
+            message_file.write(message)
+        if 0 != subprocess.call([examples_dir + 'member_sign', self.sk_file, self.cred_file, sig_file, message_filename]):
             raise SignException('****Member in directory \'' + self.directory + '\' unable to sign message: ' + message)
 
 def Verify(message, sig_file, gpk_file, sk_rev_list_file, sk_rev_list_length):
+    message_filename = examples_dir + '/msg_verify.tmp.bin'
+    with open(message_filename, 'w') as message_file:
+        message_file.write(message)
     if 0 == sk_rev_list_length:
-        if 0 != subprocess.call([examples_dir + 'verify', message, sig_file, gpk_file]):
+        if 0 != subprocess.call([examples_dir + 'verify', message_filename, sig_file, gpk_file]):
             raise VerifyException('****Unable to verify message: ' + message)
     else:
-        if 0 != subprocess.call([examples_dir + 'verify', message, sig_file, gpk_file, sk_rev_list_file, str(sk_rev_list_length)]):
+        if 0 != subprocess.call([examples_dir + 'verify', message_filename, sig_file, gpk_file, sk_rev_list_file, str(sk_rev_list_length)]):
             raise VerifyException('****Unable to verify message: ' + message)
 
 def TestNoRevoked():

--- a/test/integration-tests.py
+++ b/test/integration-tests.py
@@ -38,7 +38,7 @@ class Issuer(object):
         self.sk_rev_list = []
 
     def GetNonce(self, pk_file):
-        nonce = ''.join([random.choice(string.lowercase) for i in range(32)])
+        nonce = ''.join([random.choice(string.ascii_lowercase) for i in range(32)])
         self.nonces[nonce] = pk_file
         return nonce
 


### PR DESCRIPTION
For signing and verifying, in our examples, read the message from file rather than directly from the command line.

This allows more complex messages to be signed.