### PR TITLE
Fix coverity defects

### DIFF
--- a/src/tpm-utils/commit.c
+++ b/src/tpm-utils/commit.c
@@ -64,12 +64,14 @@ int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
                 break;
             }
 
-            if (s2_length > sizeof(s2_tpm.buffer)) {
+            int32_t g2_hash_ret;
+
+            if (s2_length > (sizeof(s2_tpm.buffer) - sizeof(g2_hash_ret))) {
                 ret = -3;
                 break;
             }
 
-            int32_t g2_hash_ret = g2_hash(&y2, s2, s2_length);
+            g2_hash_ret = g2_hash(&y2, s2, s2_length);
             if (g2_hash_ret < 0) {
                 ret = -3;
                 break;
@@ -77,7 +79,7 @@ int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
             ecp_to_tpm_format(&y2_tpm, &y2);
 
             // Concatenate (g2_hash_ret | s2) (cf. g2_hash below)
-            s2_tpm.size = s2_length + sizeof(g2_hash_ret);
+            s2_tpm.size = (uint16_t)(s2_length + sizeof(g2_hash_ret));
             memcpy(s2_tpm.buffer, &g2_hash_ret, sizeof(g2_hash_ret));
             memcpy(s2_tpm.buffer + sizeof(g2_hash_ret), s2, s2_length);
         }

--- a/test/tpm-test-utils.h
+++ b/test/tpm-test-utils.h
@@ -20,11 +20,6 @@
 
 #include <ecdaa/tpm_context.h>
 
-const char *pub_key_filename = "pub_key.txt";
-const char *handle_filename = "handle.txt";
-const char *hostname = "localhost";
-const char *port = "2321";
-
 static
 int read_public_key_from_files(ECP_FP256BN *public_key,
                                TPM_HANDLE *key_handle,
@@ -38,6 +33,11 @@ struct tpm_test_context {
 static
 int tpm_initialize(struct tpm_test_context *ctx)
 {
+    const char *pub_key_filename = "pub_key.txt";
+    const char *handle_filename = "handle.txt";
+    const char *hostname = "localhost";
+    const char *port = "2321";
+
     int ret = 0;
 
     ECP_FP256BN public_key;
@@ -82,13 +82,14 @@ int read_public_key_from_files(ECP_FP256BN *public_key,
                 ret = -1;
                 break;
             }
-            public_key_as_bytes[i] = byte;
+            public_key_as_bytes[i] = (uint8_t)byte;
         }
     } while(0);
     (void)fclose(pub_key_file_ptr);
     if (0 != ret)
         return -1;
-    ecp_FP256BN_deserialize(public_key, public_key_as_bytes);
+    if (0 != ecp_FP256BN_deserialize(public_key, public_key_as_bytes))
+        return -1;
 
     FILE *handle_file_ptr = fopen(handle_filename, "r");
     if (NULL == handle_file_ptr)


### PR DESCRIPTION
Coverity uncovered two issues with the recent `use-tpm` merge:
- A length check in `commit.c` didn't include the length of an extra `uint32_t` that also got copied into a buffer, allowing a possible buffer overflow (by the size of a `uint32_t`)
- The return value of `ecp_deserialize` wasn't being checked in `tpm-test-utils.h`