### PR TITLE
Add basename revocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.4.0")
+        VERSION "0.5.0")
 
 include(GNUInstallDirs)
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -323,6 +323,14 @@ If the signature is valid, this command returns success.
 verify message-text sig.bin gpk.bin sk_revocation_list.bin num-sks-in-sk_revocation_list
 ```
 
+# Algorithm
+
+The signature algorithm is that of
+[Camenisch et al., 2016](https://doi.org/10.1007/978-3-662-49387-8_10),
+with the exception that the "fix by Xi et al." discussed in Section 5.2 is NOT used
+when creating TPM-enabled signatures (the current TPM2.0 specification doesn't allow
+such signatures to be created).
+
 # Testing and Analysis
 
 The unit-tests are contained in the `test` directory.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,10 +40,10 @@ foreach(main_file ${ECDAA_PROGRAM_MAIN_FILES})
                 ${GENERATED_TOPLEVEL_INCLUDE_DIR})
 
         if(BUILD_SHARED_LIBS)
-              target_link_libraries(${program_name} PRIVATE ecdaa)
+              target_link_libraries(${program_name} PRIVATE ecdaa ${AMCL_LIBRARIES})
               add_dependencies(${program_name} ecdaa)
         else()
-              target_link_libraries(${program_name} PRIVATE ecdaa_static)
+              target_link_libraries(${program_name} PRIVATE ecdaa_static ${AMCL_LIBRARIES})
               add_dependencies(${program_name} ecdaa_static)
         endif()
 

--- a/examples/member_sign.c
+++ b/examples/member_sign.c
@@ -32,6 +32,7 @@ struct command_line_args {
     char *secret_key_file;
     char *sig_out_file;
     char *message_file;
+    char *basename_file;
 };
 
 void print_usage(const char *my_name);
@@ -76,8 +77,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    // Create signature
-    struct ecdaa_signature_FP256BN sig;
+    // Read message file
     uint8_t message[MAX_MESSAGE_SIZE];
     int read_ret = read_file_into_buffer(message, sizeof(message), args.message_file);
     if (read_ret < 0) {
@@ -85,13 +85,31 @@ int main(int argc, char *argv[])
         return 1;
     }
     uint32_t msg_len = (uint32_t)read_ret;
-    if (0 != ecdaa_signature_FP256BN_sign(&sig, message, msg_len, &sk, &cred, &rng)) {
+
+    // Read basename file (if requested)
+    uint8_t *basename = NULL;
+    uint32_t basename_len = 0;
+    uint8_t basename_buffer[MAX_MESSAGE_SIZE];
+    if (NULL != args.basename_file) {
+        basename = basename_buffer;
+
+        int read_ret = read_file_into_buffer(basename_buffer, sizeof(basename_buffer), args.basename_file);
+        if (read_ret < 0) {
+            fprintf(stderr, "Error reading basename file: \"%s\"\n", args.basename_file);
+            return 1;
+        }
+        basename_len = (uint32_t)read_ret;
+    }
+
+    // Create signature
+    struct ecdaa_signature_FP256BN sig;
+    if (0 != ecdaa_signature_FP256BN_sign(&sig, message, msg_len, basename, basename_len, &sk, &cred, &rng)) {
         fprintf(stderr, "Error signing message: \"%s\"\n", (char*)message);
         return 1;
     }
 
     // Write signature to file
-    ecdaa_signature_FP256BN_serialize(buffer, &sig);
+    ecdaa_signature_FP256BN_serialize(buffer, &sig, basename_len != 0);
     if (ECDAA_SIGNATURE_FP256BN_LENGTH != write_buffer_to_file(args.sig_out_file, buffer, ECDAA_SIGNATURE_FP256BN_LENGTH)) {
         fprintf(stderr, "Error writing signature to file: \"%s\"\n", args.sig_out_file);
         return 1;
@@ -106,22 +124,27 @@ void print_usage(const char *my_name)
                     "<secret-key-input-file> "
                     "<credential-input-file> "
                     "<signature-output-file> "
-                    "<message-file>\n"
-                    "NOTE: message must be smaller than %dbytes\n",
+                    "<message-file> "
+                    "[<basename-file>]\n"
+                    "\nNOTE: message must be smaller than %dbytes\n",
            my_name, MAX_MESSAGE_SIZE);
 }
 
 int parse_args(struct command_line_args *args_out, int argc, char *argv[])
 {
-    if (5 != argc) {
+    if (5 == argc || 6 == argc) {
+        args_out->secret_key_file = argv[1];
+        args_out->credential_file = argv[2];
+        args_out->sig_out_file = argv[3];
+        args_out->message_file = argv[4];
+        args_out->basename_file = NULL;
+        if (6 == argc) {
+            args_out->basename_file = argv[5];
+        }
+    } else {
         print_usage(argv[0]);
         return 1;
     }
-
-    args_out->secret_key_file = argv[1];
-    args_out->credential_file = argv[2];
-    args_out->sig_out_file = argv[3];
-    args_out->message_file = argv[4];
 
     return 0;
 }

--- a/examples/verify.c
+++ b/examples/verify.c
@@ -33,13 +33,18 @@ struct command_line_args {
     char *gpk_file;
     char *sk_rev_list_file;
     unsigned number_of_sk_revs;
+    char *bsn_rev_list_file;
+    unsigned number_of_bsn_revs;
+    char *basename_file;
 };
 
 void print_usage(const char *my_name);
 
 int parse_args(struct command_line_args *args_out, int argc, char *argv[]);
 
-int parse_sk_rev_list_file(struct ecdaa_revocation_list_FP256BN *rev_list_out, const char *filename, unsigned num_revs);
+int parse_sk_rev_list_file(struct ecdaa_revocations_FP256BN *rev_list_out, const char *filename, unsigned num_revs);
+
+int parse_bsn_rev_list_file(struct ecdaa_revocations_FP256BN *revocations_out, const char *filename, unsigned num_revs);
 
 int main(int argc, char *argv[])
 {
@@ -47,11 +52,30 @@ int main(int argc, char *argv[])
 
     uint8_t buffer[1024];
 
+    struct ecdaa_revocations_FP256BN revocations;
+    revocations.sk_list = NULL;
+    revocations.bsn_list = NULL;
+
     // Parse command line
     struct command_line_args args;
     if (0 != parse_args(&args, argc, argv)) {
         ret = 1;
         goto cleanup;
+    }
+
+    // Read basename file (if requested)
+    uint8_t *basename = NULL;
+    uint32_t basename_len = 0;
+    uint8_t basename_buffer[MAX_MESSAGE_SIZE];
+    if (NULL != args.basename_file) {
+        basename = basename_buffer;
+
+        int read_ret = read_file_into_buffer(basename_buffer, sizeof(basename_buffer), args.basename_file);
+        if (read_ret < 0) {
+            fprintf(stderr, "Error reading basename file: \"%s\"\n", args.basename_file);
+            return 1;
+        }
+        basename_len = (uint32_t)read_ret;
     }
 
     // Read signature from disk
@@ -61,7 +85,7 @@ int main(int argc, char *argv[])
         ret = 1;
         goto cleanup;
     }
-    if (0 != ecdaa_signature_FP256BN_deserialize(&sig, buffer)) {
+    if (0 != ecdaa_signature_FP256BN_deserialize(&sig, buffer, basename_len != 0)) {
         fputs("Error deserializing signature\n", stderr);
         ret = 1;
         goto cleanup;
@@ -81,14 +105,19 @@ int main(int argc, char *argv[])
     }
 
     // Read in sk_rev_list from disk.
-    struct ecdaa_revocation_list_FP256BN sk_rev_list;
-    if (0 != parse_sk_rev_list_file(&sk_rev_list, args.sk_rev_list_file, args.number_of_sk_revs)) {
-        fputs("Error parsing revocation list file\n", stderr);
+    if (0 != parse_sk_rev_list_file(&revocations, args.sk_rev_list_file, args.number_of_sk_revs)) {
+        fputs("Error parsing secret-key revocation list file\n", stderr);
         ret = 1;
         goto cleanup;
     }
 
-    // Verify signature
+    // Read in bsn_rev_list from disk.
+    if (0 != parse_bsn_rev_list_file(&revocations, args.bsn_rev_list_file, args.number_of_bsn_revs)) {
+        fputs("Error parsing basename-signature revocation list file\n", stderr);
+        return 1;
+    }
+
+    // Read message from disk.
     uint8_t message[MAX_MESSAGE_SIZE];
     int read_ret = read_file_into_buffer(message, sizeof(message), args.message_file);
     if (read_ret < 0) {
@@ -97,17 +126,21 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
     uint32_t msg_len = (uint32_t)read_ret;
-    if (0 != ecdaa_signature_FP256BN_verify(&sig, &gpk, &sk_rev_list, message, msg_len)) {
+
+    // Verify signature
+    if (0 != ecdaa_signature_FP256BN_verify(&sig, &gpk, &revocations, message, msg_len, basename, basename_len)) {
         fprintf(stderr, "Signature not valid!\n");
         ret = 1;
         goto cleanup;
     }
 
-cleanup:
-    if (NULL != sk_rev_list.list)
-        free(sk_rev_list.list);
-
     printf("Signature successfully verified!\n");
+
+cleanup:
+    if (NULL != revocations.sk_list) {
+        free(revocations.sk_list);
+        free(revocations.bsn_list);
+    }
 
     return ret;
 }
@@ -118,31 +151,39 @@ void print_usage(const char *my_name)
                     "<message-file> "
                     "<signature-input-file> "
                     "<group-public-key-input-file> "
-                    "[<secret-key-revocation-list-input-file>] "
-                    "[<number-of-secret-key-revocations-in-list>]\n"
-                    "NOTE: message must be smaller than %dbytes\n",
+                    "<secret-key-revocation-list-input-file> "
+                    "<number-of-secret-key-revocations-in-list> "
+                    "<basename-signature-revocation-list-input-file> "
+                    "<number-of-basename-signature-revocations-in-list> "
+                    "[<basename-file>]\n"
+                    "\nNOTE: message must be smaller than %dbytes\n",
            my_name, MAX_MESSAGE_SIZE);
 }
 
 int parse_args(struct command_line_args *args_out, int argc, char *argv[])
 {
-    if (6 == argc || 4 == argc) {
+    if (8 == argc || 9 == argc) {
         args_out->message_file = argv[1];
         args_out->sig_file = argv[2];
         args_out->gpk_file = argv[3];
 
-        args_out->sk_rev_list_file = NULL;
-        args_out->number_of_sk_revs = 0;
+        args_out->sk_rev_list_file = argv[4];
+        int num_revs_in = atoi(argv[5]);
+        if (0 == num_revs_in) {
+            fprintf(stderr, "Warning: Bad value for <number-of-secret-key-revocations-in-list>: %s\nUsing 0\n", argv[5]);
+        }
+        args_out->number_of_sk_revs = (unsigned)num_revs_in;
 
-        if (6 == argc) {
-            args_out->sk_rev_list_file = argv[4];
-            int num_revs_in = atoi(argv[5]);
-            if (0 >= num_revs_in) {
-                fprintf(stderr, "Bad value for <number-of-secret-key-revocations-in-list>: %s\n", argv[4]);
-                print_usage(argv[0]);
-                return 1;
-            }
-            args_out->number_of_sk_revs = (unsigned)num_revs_in;
+        args_out->bsn_rev_list_file = argv[6];
+        int num_bsn_revs_in = atoi(argv[7]);
+        if (0 == num_revs_in) {
+            fprintf(stderr, "Warning: Bad value for <number-of-basename-signature-revocations-in-list>: %s\nUsing 0\n", argv[7]);
+        }
+        args_out->number_of_bsn_revs = (unsigned)num_bsn_revs_in;
+
+        args_out->basename_file = NULL;
+        if (9 == argc) {
+            args_out->basename_file = argv[8];
         }
     } else {
         print_usage(argv[0]);
@@ -152,12 +193,12 @@ int parse_args(struct command_line_args *args_out, int argc, char *argv[])
     return 0;
 }
 
-int parse_sk_rev_list_file(struct ecdaa_revocation_list_FP256BN *rev_list_out, const char *filename, unsigned num_revs)
+int parse_sk_rev_list_file(struct ecdaa_revocations_FP256BN *revocations_out, const char *filename, unsigned num_revs)
 {
     int ret = 0;
 
-    rev_list_out->list = NULL;
-    rev_list_out->length = 0;
+    revocations_out->sk_list = NULL;
+    revocations_out->sk_length = 0;
 
     if (NULL != filename && num_revs != 0) {
         // Allocate a buffer to hold the full file.
@@ -169,8 +210,8 @@ int parse_sk_rev_list_file(struct ecdaa_revocation_list_FP256BN *rev_list_out, c
         }
 
         // Allocate the revocation list array.
-        rev_list_out->list = malloc(num_revs * sizeof(struct ecdaa_member_secret_key_FP256BN));
-        if (NULL == rev_list_out->list) {
+        revocations_out->sk_list = malloc(num_revs * sizeof(struct ecdaa_member_secret_key_FP256BN));
+        if (NULL == revocations_out->sk_list) {
             ret = 1;
             goto cleanup;
         }
@@ -184,9 +225,9 @@ int parse_sk_rev_list_file(struct ecdaa_revocation_list_FP256BN *rev_list_out, c
 
         // Deserialize each secret key and add it to the list.
         for (unsigned i = 0; i < num_revs; i++) {
-            int deserial_ret = ecdaa_member_secret_key_FP256BN_deserialize(&rev_list_out->list[i],
+            int deserial_ret = ecdaa_member_secret_key_FP256BN_deserialize(&revocations_out->sk_list[i],
                                                                          buffer + i*ECDAA_MEMBER_SECRET_KEY_FP256BN_LENGTH);
-            rev_list_out->length++;
+            revocations_out->sk_length++;
             if (0 != deserial_ret) {
                 ret = 1;
                 goto cleanup;
@@ -198,11 +239,71 @@ cleanup:
             free(buffer);
 
         if (0 != ret) {
-            if (NULL != rev_list_out->list)
-                free(rev_list_out->list);
+            if (NULL != revocations_out->sk_list)
+                free(revocations_out->sk_list);
 
-            rev_list_out->list = NULL;
-            rev_list_out->length = 0;
+            revocations_out->sk_list = NULL;
+            revocations_out->sk_length = 0;
+        }
+    }
+
+    return ret;
+}
+
+int parse_bsn_rev_list_file(struct ecdaa_revocations_FP256BN *revocations_out, const char *filename, unsigned num_revs)
+{
+    int ret = 0;
+
+    revocations_out->bsn_list = NULL;
+    revocations_out->bsn_length = 0;
+
+    size_t point_size = (2*MODBYTES_256_56 + 1);
+
+    if (NULL != filename && num_revs != 0) {
+        // Allocate a buffer to hold the full file.
+        size_t file_length = num_revs * point_size;
+        uint8_t *buffer = malloc(file_length);
+        if (NULL == buffer) {
+            ret = 1;
+            goto cleanup;
+        }
+
+        // Allocate the revocation list array.
+        revocations_out->bsn_list = malloc(num_revs * sizeof(ECP_FP256BN));
+        if (NULL == revocations_out->bsn_list) {
+            ret = 1;
+            goto cleanup;
+        }
+
+        // Read the revocation list in from disk.
+        int read_ret = read_file_into_buffer(buffer, file_length, filename);
+        if (read_ret < 0 || file_length != (size_t)read_ret) {
+            ret = 1;
+            goto cleanup;
+        }
+
+        // Deserialize each basename signature and add it to the list.
+        for (unsigned i = 0; i < num_revs; i++) {
+            // Nb. This does NOT check that the point is in the proper group.
+            octet point_as_octet = {.val=(char*)(buffer+i*point_size), .len=point_size};
+            int deserial_ret = ECP_FP256BN_fromOctet(&revocations_out->bsn_list[i], &point_as_octet);
+            revocations_out->bsn_length++;
+            if (0 != deserial_ret) {
+                ret = 1;
+                goto cleanup;
+            }
+        }
+
+cleanup:
+        if (NULL != buffer)
+            free(buffer);
+
+        if (0 != ret) {
+            if (NULL != revocations_out->bsn_list)
+                free(revocations_out->bsn_list);
+
+            revocations_out->bsn_list = NULL;
+            revocations_out->bsn_length = 0;
         }
     }
 

--- a/include/ecdaa.h
+++ b/include/ecdaa.h
@@ -25,7 +25,7 @@
 #include <ecdaa/issuer_keypair_ZZZ.h>
 #include <ecdaa/member_keypair_ZZZ.h>
 #include <ecdaa/prng.h>
-#include <ecdaa/revocation_list_ZZZ.h>
+#include <ecdaa/revocations_ZZZ.h>
 #include <ecdaa/signature_ZZZ.h>
 #include <ecdaa/signature_TPM.h>
 #include <ecdaa/tpm_context.h>

--- a/include/ecdaa/revocations_ZZZ.h
+++ b/include/ecdaa/revocations_ZZZ.h
@@ -16,8 +16,8 @@
  *
  *****************************************************************************/
 
-#ifndef ECDAA_REVOCATION_LIST_ZZZ_H
-#define ECDAA_REVOCATION_LIST_ZZZ_H
+#ifndef ECDAA_REVOCATIONS_ZZZ_H
+#define ECDAA_REVOCATIONS_ZZZ_H
 #pragma once
 
 #ifdef __cplusplus
@@ -26,17 +26,22 @@ extern "C" {
 
 struct ecdaa_member_secret_key_ZZZ;
 
+#include <amcl/ecp_ZZZ.h>
+
 #include <stddef.h>
 
 /*
- * Secret-key revocation list.
+ * Secret-key revocation list and
+ * basename-signature revocation list.
  *
  * `list` is an array of `ecdaa_member_secret_key_ZZZ`s.
  * `length` is the size of `list`.
  */
-struct ecdaa_revocation_list_ZZZ {
-    size_t length;
-    struct ecdaa_member_secret_key_ZZZ *list;
+struct ecdaa_revocations_ZZZ {
+    size_t sk_length;
+    struct ecdaa_member_secret_key_ZZZ *sk_list;
+    size_t bsn_length;
+    ECP_ZZZ *bsn_list;
 };
 
 #ifdef __cplusplus

--- a/include/ecdaa/signature_TPM.h
+++ b/include/ecdaa/signature_TPM.h
@@ -40,6 +40,8 @@ struct ecdaa_tpm_context;
 int ecdaa_signature_TPM_sign(struct ecdaa_signature_FP256BN *signature_out,
                              const uint8_t* message,
                              uint32_t message_len,
+                             const uint8_t* basename,
+                             uint32_t basename_len,
                              struct ecdaa_credential_FP256BN *cred,
                              struct ecdaa_prng *prng,
                              struct ecdaa_tpm_context *tpm_ctx);

--- a/src/amcl-extensions/big_XXX.c
+++ b/src/amcl-extensions/big_XXX.c
@@ -63,6 +63,35 @@ void big_XXX_from_two_message_hash(BIG_XXX *big_out,
     convert_hash_to_big_XXX(big_out, &hash);
 }
 
+void big_XXX_from_three_message_hash(BIG_XXX *big_out,
+                                     const uint8_t *msg1_in,
+                                     uint32_t msg1_len,
+                                     const uint8_t *msg2_in,
+                                     uint32_t msg2_len,
+                                     const uint8_t *msg3_in,
+                                     uint32_t msg3_len)
+{
+    hash256 hash;
+    HASH256_init(&hash);
+
+    // Process msg1 one-byte-at-a-time.
+    for (uint32_t i=0; i < msg1_len; ++i) {
+        HASH256_process(&hash, msg1_in[i]);
+    }
+
+    // Process msg2 one-byte-at-a-time.
+    for (uint32_t i=0; i < msg2_len; ++i) {
+        HASH256_process(&hash, msg2_in[i]);
+    }
+
+    // Process msg3 one-byte-at-a-time.
+    for (uint32_t i=0; i < msg3_len; ++i) {
+        HASH256_process(&hash, msg3_in[i]);
+    }
+
+    convert_hash_to_big_XXX(big_out, &hash);
+}
+
 void big_XXX_mod_mul_and_add(BIG_XXX *big_out,
                              BIG_XXX summand,
                              BIG_XXX multiplicand1,

--- a/src/amcl-extensions/big_XXX.h
+++ b/src/amcl-extensions/big_XXX.h
@@ -51,6 +51,17 @@ void big_XXX_from_two_message_hash(BIG_XXX *big_out,
                                    uint32_t msg2_len);
 
 /*
+ * Same as big_XXX_from_hash, but with three input messages.
+ */
+void big_XXX_from_three_message_hash(BIG_XXX *big_out,
+                                     const uint8_t *msg1_in,
+                                     uint32_t msg1_len,
+                                     const uint8_t *msg2_in,
+                                     uint32_t msg2_len,
+                                     const uint8_t *msg3_in,
+                                     uint32_t msg3_len);
+
+/*
  * Multiply two BIG_XXX's, then add the product to a third BIG_XXX, all modulo a given modulus.
  *
  * BIG_XXX_out = [ summand + (multiplicand1 * multiplicand2) ] mod modulus

--- a/src/amcl-extensions/ecp_ZZZ.c
+++ b/src/amcl-extensions/ecp_ZZZ.c
@@ -17,6 +17,7 @@
  *****************************************************************************/
 
 #include "./ecp_ZZZ.h"
+#include "./big_XXX.h"
 
 size_t ecp_ZZZ_length(void)
 {
@@ -90,4 +91,23 @@ int ecp_ZZZ_deserialize(ECP_ZZZ *point_out,
     }
 
     return 0;
+}
+
+int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t message_length)
+{
+    // Following the Appendix of Chen and Li, 2013
+
+    BIG_XXX curve_order;
+    BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
+
+    for (int32_t i=0; i < 232; i++) {
+        BIG_XXX x;
+        big_XXX_from_two_message_hash(&x, (uint8_t*)&i, sizeof(i), message, message_length);
+        BIG_XXX_mod(x, curve_order);
+        if (ECP_ZZZ_setx(point_out, x, 0))
+            return i;
+    }
+
+    // If we reach here, we ran out of tries, so return error.
+    return -1;
 }

--- a/src/amcl-extensions/ecp_ZZZ.h
+++ b/src/amcl-extensions/ecp_ZZZ.h
@@ -57,6 +57,23 @@ void ecp_ZZZ_serialize(uint8_t *buffer_out,
 int ecp_ZZZ_deserialize(ECP_ZZZ *point_out,
                         uint8_t *buffer);
 
+/*
+ * Hash a message into an ECP_ZZZ point.
+ *
+ * The curve point generated from the message m is found as follows (cf. Chen and Li, 2013):
+ *  1. Set i := 0 be a 32-bit unsigned integer.
+ *  2. Compute x := H(i, m).
+ *  3. Compute z := x3 + ax + b mod q.
+ *  4. Compute y := √z mod q. If y does not exist, set i := i + 1,
+ *      repeat step 2 if i < 232, otherwise, report failure.
+ *  5. Set y := min(y, q − y).
+ *
+ * Returns:
+ *  i on success (i is 32-bit unsigned integer used in construction above)
+ *  -1 on failure
+ */
+int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t message_length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/internal/schnorr_TPM.c
+++ b/src/internal/schnorr_TPM.c
@@ -27,38 +27,69 @@
 #include <assert.h>
 
 enum {
-    THREE_ECP_LENGTH = 3*ECP_FP256BN_LENGTH
+    THREE_ECP_LENGTH = 3*ECP_FP256BN_LENGTH,
+    SIX_ECP_LENGTH = 6*ECP_FP256BN_LENGTH
 };
 
 int schnorr_sign_TPM(BIG_256_56 *c_out,
                      BIG_256_56 *s_out,
+                     ECP_FP256BN *K_out,
                      const uint8_t *msg_in,
                      uint32_t msg_len,
                      ECP_FP256BN *basepoint,
                      ECP_FP256BN *public_key,
+                     const uint8_t *basename,
+                     uint32_t basename_len,
                      struct ecdaa_tpm_context *tpm_ctx)
 {
     int ret = 0;
 
     // 1) (Commit) (call TPM2_Commit)
-    ECP_FP256BN K, L, R;
-    ret = tpm_commit(tpm_ctx, basepoint, NULL, 0, &K, &L, &R);
+    ECP_FP256BN L, R;
+    ret = tpm_commit(tpm_ctx, basepoint, basename, basename_len, K_out, &L, &R);
     if (0 != ret)
         return -1;
 
-    // 2) (Sign 1) Compute c = Hash( R | basepoint | public_key | msg_in )
-    //      (modular-reduce c, too).
-    uint8_t hash_input_begin[THREE_ECP_LENGTH];
-    assert(3*ECP_FP256BN_LENGTH == sizeof(hash_input_begin));
-    ecp_FP256BN_serialize(hash_input_begin, &R);
-    ecp_FP256BN_serialize(hash_input_begin+ECP_FP256BN_LENGTH, basepoint);
-    ecp_FP256BN_serialize(hash_input_begin+2*ECP_FP256BN_LENGTH, public_key);
-    big_256_56_from_two_message_hash(c_out, hash_input_begin, sizeof(hash_input_begin), msg_in, msg_len);
+    // If we're not creating a basename-signature, but K_out != NULL,
+    //  set K_out:=g1_generator (so it de-serializes OK).
+    if (0 == basename_len && NULL != K_out) {
+        ecp_FP256BN_set_to_generator(K_out);
+    }
+    
+    // 2) (Sign 1) Compute hash
+    if (basename_len != 0) {
+        // 2i) Find P2 by hashing basename
+        ECP_FP256BN P2;
+        int32_t hash_ret = ecp_FP256BN_fromhash(&P2, basename, basename_len);
+        if (hash_ret < 0)
+            return -1;
+
+        // 2ii) Compute c = Hash( R | basepoint | public_key | L | P2 | K_out | basename | msg_in )
+        uint8_t hash_input_begin[SIX_ECP_LENGTH];
+        assert(6*ECP_FP256BN_LENGTH == sizeof(hash_input_begin));
+        ecp_FP256BN_serialize(hash_input_begin, &R);
+        ecp_FP256BN_serialize(hash_input_begin+ECP_FP256BN_LENGTH, basepoint);
+        ecp_FP256BN_serialize(hash_input_begin+2*ECP_FP256BN_LENGTH, public_key);
+        ecp_FP256BN_serialize(hash_input_begin+3*ECP_FP256BN_LENGTH, &L);
+        ecp_FP256BN_serialize(hash_input_begin+4*ECP_FP256BN_LENGTH, &P2);
+        ecp_FP256BN_serialize(hash_input_begin+5*ECP_FP256BN_LENGTH, K_out);
+        big_256_56_from_three_message_hash(c_out, hash_input_begin, sizeof(hash_input_begin), basename, basename_len, msg_in, msg_len);
+    } else {
+        // Compute c = Hash( R | basepoint | public_key | msg_in )
+        uint8_t hash_input_begin[THREE_ECP_LENGTH];
+        assert(3*ECP_FP256BN_LENGTH == sizeof(hash_input_begin));
+        ecp_FP256BN_serialize(hash_input_begin, &R);
+        ecp_FP256BN_serialize(hash_input_begin+ECP_FP256BN_LENGTH, basepoint);
+        ecp_FP256BN_serialize(hash_input_begin+2*ECP_FP256BN_LENGTH, public_key);
+        big_256_56_from_two_message_hash(c_out, hash_input_begin, sizeof(hash_input_begin), msg_in, msg_len);
+    }
+
+    // 3) (Sign 2) Modular-reduce c
     BIG_256_56 curve_order;
     BIG_256_56_rcopy(curve_order, CURVE_Order_FP256BN);
     BIG_256_56_mod(*c_out, curve_order);
 
-    // 3) (Sign 2) (Call TPM2_Sign)
+    // 4) (Sign 3) (Call TPM2_Sign)
     // TODO: Don't double-copy the hash (first into a BIG, then back out of a BIG)
     TPMT_SIGNATURE signature;
     TPM2B_DIGEST digest = {.size=MODBYTES_256_56, .buffer={0}};
@@ -67,7 +98,7 @@ int schnorr_sign_TPM(BIG_256_56 *c_out,
     if (0 != ret)
         return -2;
 
-    // 4) (Output) Convert TPMS_SIGNATURE_ECC.signatureS into BIG_256_56
+    // 5) (Output) Convert TPMS_SIGNATURE_ECC.signatureS into BIG_256_56
     assert(MODBYTES_256_56 == signature.signature.ecdaa.signatureS.size);
     BIG_256_56_fromBytes(*s_out, (char*)signature.signature.ecdaa.signatureS.buffer);
 

--- a/src/internal/schnorr_TPM.h
+++ b/src/internal/schnorr_TPM.h
@@ -37,8 +37,12 @@ struct ecdaa_prng;
 /*
  * Perform TPM2_Commit/TPM2_Sign signature of msg_in, allowing for a non-standard basepoint.
  *
- * c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
- * s_out = s = RAND(Z_p) + c * private_key,
+ * if basename:
+ *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | RAND(Z_p)*P2 | P2 | [private_key]P2 | basename | msg_in )
+ *      where P2 = the curve point hashed from basename (cf. `ecp_ZZZ_fromhash`)
+ * else:
+ *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
+ * s_out = RAND(Z_p) + c_out * private_key,
  *
  * Note: All random numbers are chosen by the TPM.
  *
@@ -52,10 +56,13 @@ struct ecdaa_prng;
  */
 int schnorr_sign_TPM(BIG_256_56 *c_out,
                      BIG_256_56 *s_out,
+                     ECP_FP256BN *K_out,
                      const uint8_t *msg_in,
                      uint32_t msg_len,
                      ECP_FP256BN *basepoint,
                      ECP_FP256BN *public_key,
+                     const uint8_t *basename,
+                     uint32_t basename_length,
                      struct ecdaa_tpm_context *tpm_ctx);
 
 #ifdef __cplusplus

--- a/src/internal/schnorr_ZZZ.h
+++ b/src/internal/schnorr_ZZZ.h
@@ -43,10 +43,14 @@ void schnorr_keygen_ZZZ(ECP_ZZZ *public_out,
                         struct ecdaa_prng *prng);
 
 /*
- * Perform Schnorr signature of msg_in, allowing for a non-standard basepoint.
+ * Perform Schnorr signature of msg_in, allowing for a non-standard basepoint and basename.
  *
- * c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
- * s_out = s = RAND(Z_p) + c_out * private_key
+ * if basename:
+ *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | RAND(Z_p)*P2 | P2 | [private_key]P2 | basename | msg_in )
+ *      where P2 = the curve point hashed from basename (cf. `ecp_ZZZ_fromhash`)
+ * else:
+ *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
+ * s_out = RAND(Z_p) + c_out * private_key
  *
  * public_key = private_key * basepoint
  *
@@ -58,11 +62,14 @@ void schnorr_keygen_ZZZ(ECP_ZZZ *public_out,
  */
 int schnorr_sign_ZZZ(BIG_XXX *c_out,
                      BIG_XXX *s_out,
+                     ECP_ZZZ *K_out,
                      const uint8_t *msg_in,
                      uint32_t msg_len,
                      ECP_ZZZ *basepoint,
                      ECP_ZZZ *public_key,
                      BIG_XXX private_key,
+                     const uint8_t *basename,
+                     uint32_t basename_len,
                      struct ecdaa_prng *prng);
 
 /*
@@ -80,10 +87,13 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
  */
 int schnorr_verify_ZZZ(BIG_XXX c,
                        BIG_XXX s,
+                       ECP_ZZZ *K,
                        const uint8_t *msg_in,
                        uint32_t msg_len,
                        ECP_ZZZ *basepoint,
-                       ECP_ZZZ *public_key);
+                       ECP_ZZZ *public_key,
+                       const uint8_t *basename,
+                       uint32_t basename_len);
 
 /*
  * Perform an 'credential-Schnorr' signature, used by an Issuer when signing credentials.

--- a/src/member_keypair_TPM.c
+++ b/src/member_keypair_TPM.c
@@ -38,10 +38,13 @@ int ecdaa_member_key_pair_TPM_generate(struct ecdaa_member_public_key_FP256BN *p
     ecp_FP256BN_set_to_generator(&basepoint);
     ret = schnorr_sign_TPM(&pk->c,
                            &pk->s,
+                           NULL,
                            nonce,
                            nonce_length,
                            &basepoint,
                            &pk->Q,
+                           NULL,
+                           0,
                            tpm_ctx);
 
     return ret;

--- a/src/member_keypair_ZZZ.c
+++ b/src/member_keypair_ZZZ.c
@@ -49,11 +49,14 @@ int ecdaa_member_key_pair_ZZZ_generate(struct ecdaa_member_public_key_ZZZ *pk,
     ecp_ZZZ_set_to_generator(&basepoint);
     int sign_ret = schnorr_sign_ZZZ(&pk->c,
                                     &pk->s,
+                                    NULL,
                                     nonce,
                                     nonce_length,
                                     &basepoint,
                                     &pk->Q,
                                     sk->sk,
+                                    NULL,
+                                    0,
                                     prng);
 
     return sign_ret;
@@ -69,10 +72,13 @@ int ecdaa_member_public_key_ZZZ_validate(struct ecdaa_member_public_key_ZZZ *pk,
     ecp_ZZZ_set_to_generator(&basepoint);
     int sign_ret = schnorr_verify_ZZZ(pk->c,
                                       pk->s,
+                                      NULL,
                                       nonce_in,
                                       nonce_length,
                                       &basepoint,
-                                      &pk->Q);
+                                      &pk->Q,
+                                      NULL,
+                                      0);
     if (0 != sign_ret)
         ret = -1;
 

--- a/src/signature_TPM.c
+++ b/src/signature_TPM.c
@@ -27,6 +27,8 @@
 int ecdaa_signature_TPM_sign(struct ecdaa_signature_FP256BN *signature_out,
                              const uint8_t* message,
                              uint32_t message_len,
+                             const uint8_t* basename,
+                             uint32_t basename_len,
                              struct ecdaa_credential_FP256BN *cred,
                              struct ecdaa_prng *prng,
                              struct ecdaa_tpm_context *tpm_ctx)
@@ -38,10 +40,13 @@ int ecdaa_signature_TPM_sign(struct ecdaa_signature_FP256BN *signature_out,
     //  where the basepoint is S.
     int sign_ret = schnorr_sign_TPM(&signature_out->c,
                                     &signature_out->s,
+                                    &signature_out->K,
                                     message,
                                     message_len,
                                     &signature_out->S,
                                     &signature_out->W,
+                                    basename,
+                                    basename_len,
                                     tpm_ctx);
     
     return sign_ret;

--- a/src/tpm-utils/commit.h
+++ b/src/tpm-utils/commit.h
@@ -33,14 +33,6 @@ extern "C" {
 /*
  * Call TPM2_Commit, using the key handle in tpm_ctx.
  *
- * The curve point generated from the message s2 is found as follows (cf. Chen and Li, 2013):
- *  1. Set i := 0 be a 32-bit unsigned integer.
- *  2. Compute x := H(i, m).
- *  3. Compute z := x3 + ax + b mod q.
- *  4. Compute y := √z mod q. If y does not exist, set i :=
- *  i + 1, repeat step 2 if i < 232, otherwise, report failure.
- *  5. Set y := min(y, q − y).
- *
  * Returns:
  * 0 on success
  * -1 if TPM2_Commit fails (check tpm-ctx->last_return_code)
@@ -52,7 +44,7 @@ extern "C" {
  */
 int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
                ECP_FP256BN *P1,
-               uint8_t *s2,
+               const uint8_t *s2,
                uint32_t s2_length,
                ECP_FP256BN *K,
                ECP_FP256BN *L,

--- a/test/integration-tests.py
+++ b/test/integration-tests.py
@@ -46,7 +46,7 @@ class Issuer(object):
         if self.nonces.pop(nonce, None) is not pk_file:
             raise JoinException('****Issuer in directory \'' + self.directory + '\' got unknown or unmatched nonce: ' + nonce)
 
-        if 0 != subprocess.call([examples_dir + 'issuer_respond_to_join_request',
+        if 0 != subprocess.call([examples_dir + '/issuer_respond_to_join_request',
                                  pk_file,
                                  self.isk_file,
                                  cred_file,
@@ -73,7 +73,7 @@ class Member(object):
         self.directory = directory
 
         self.gpk_file = self.directory + '/gpk.bin'
-        if 0 != subprocess.call([examples_dir + 'extract_group_public_key', issuer.ipk_file, self.gpk_file]):
+        if 0 != subprocess.call([examples_dir + '/extract_group_public_key', issuer.ipk_file, self.gpk_file]):
             raise JoinException('****Error extracting group public key from file: ' + issuer.ipk_file)
 
         self.sk_file = self.directory + '/sk.bin'
@@ -81,7 +81,7 @@ class Member(object):
 
         nonce = issuer.GetNonce(self.pk_file)
 
-        if 0 != subprocess.call([examples_dir + 'member_request_join', nonce, self.pk_file, self.sk_file]):
+        if 0 != subprocess.call([examples_dir + '/member_request_join', nonce, self.pk_file, self.sk_file]):
             raise JoinException('****Member in directory \'' + self.directory + '\' unable to create join request')
 
         self.cred_file = self.directory + '/cred.bin'
@@ -94,7 +94,7 @@ class Member(object):
             raise JoinException('Issuer should have rejected our fake nonce')
         issuer.ProcessJoinRequest(self.pk_file, self.cred_file, cred_sig_file, nonce)
 
-        if 0 != subprocess.call([examples_dir + 'member_process_join_response',
+        if 0 != subprocess.call([examples_dir + '/member_process_join_response',
                                  self.pk_file,
                                  self.gpk_file,
                                  self.cred_file,
@@ -106,19 +106,15 @@ class Member(object):
         message_filename = examples_dir + '/msg_sign.tmp.bin'
         with open(message_filename, 'w') as message_file:
             message_file.write(message)
-        if 0 != subprocess.call([examples_dir + 'member_sign', self.sk_file, self.cred_file, sig_file, message_filename]):
+        if 0 != subprocess.call([examples_dir + '/member_sign', self.sk_file, self.cred_file, sig_file, message_filename]):
             raise SignException('****Member in directory \'' + self.directory + '\' unable to sign message: ' + message)
 
 def Verify(message, sig_file, gpk_file, sk_rev_list_file, sk_rev_list_length):
     message_filename = examples_dir + '/msg_verify.tmp.bin'
     with open(message_filename, 'w') as message_file:
         message_file.write(message)
-    if 0 == sk_rev_list_length:
-        if 0 != subprocess.call([examples_dir + 'verify', message_filename, sig_file, gpk_file]):
-            raise VerifyException('****Unable to verify message: ' + message)
-    else:
-        if 0 != subprocess.call([examples_dir + 'verify', message_filename, sig_file, gpk_file, sk_rev_list_file, str(sk_rev_list_length)]):
-            raise VerifyException('****Unable to verify message: ' + message)
+    if 0 != subprocess.call([examples_dir + '/verify', message_filename, sig_file, gpk_file, sk_rev_list_file, str(sk_rev_list_length), '', '0']):
+        raise VerifyException('****Unable to verify message: ' + message)
 
 def TestNoRevoked():
     issuer = Issuer('issuer')
@@ -126,7 +122,10 @@ def TestNoRevoked():
     message = 'Message'
     sig_file = 'sig.bin'
     member.Sign(message, sig_file)
-    Verify(message, sig_file, member.gpk_file, '', 0)
+
+    sk_rev_list_file = 'sk_rev_list.bin'
+    issuer.GetRevokedSecretKeyListFile(sk_rev_list_file)
+    Verify(message, sig_file, member.gpk_file, sk_rev_list_file, 0)
 
 def TestTwoRevoked():
     issuer = Issuer('issuer_for_revs')
@@ -176,8 +175,12 @@ def TestWrongGroup():
     message = 'Message'
     sig_file = 'sig.bin'
     member2.Sign(message, sig_file)
+
+    sk_rev_list_file = 'sk_rev_list.bin'
+    issuer1.GetRevokedSecretKeyListFile(sk_rev_list_file)
+
     try:
-        Verify(message, sig_file, member1.gpk_file, '', 0)
+        Verify(message, sig_file, member1.gpk_file, sk_rev_list_file, 0)
     except VerifyException as e:
         pass
     else:


### PR DESCRIPTION
Fixes #5 

This continues to use the Camenisch et al, 2016 algorithm, which always included pseudonyms and linking (the FIDO version removes that capability).

Signatures without pseudonyms are still allowed. If a verifier doesn't use a basename with a signature that was produced with one (or vice versa), the verification will fail. In this way, interop with FIDO is maintained.