### PR TITLE
Before printf'ing message, in examples/member_sign.c, ensure it's null-terminated

### DIFF
--- a/examples/member_sign.c
+++ b/examples/member_sign.c
@@ -104,6 +104,7 @@ int main(int argc, char *argv[])
     // Create signature
     struct ecdaa_signature_FP256BN sig;
     if (0 != ecdaa_signature_FP256BN_sign(&sig, message, msg_len, basename, basename_len, &sk, &cred, &rng)) {
+        message[msg_len] = 0;
         fprintf(stderr, "Error signing message: \"%s\"\n", (char*)message);
         return 1;
     }


### PR DESCRIPTION
Coverity found a bug in our examples code. If we can't fail when creating the signature, we also print the message itself to stderr. However, this message is just a uint8_t buffer, and we weren't null-terminating it before casting to char* and printing.

This commit fixes that, by explicitly setting `message[msg_len] = 0`.