### PR TITLE
Public key as bytes in init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.5.0")
+        VERSION "0.6.0")
 
 include(GNUInstallDirs)
 include(CTest)

--- a/include/ecdaa/tpm_context.h
+++ b/include/ecdaa/tpm_context.h
@@ -56,12 +56,15 @@ struct ecdaa_tpm_context {
  *
  * Only password authentication (for the ownership of the Schnorr keypair) is supported.
  *
+ * `public_key_in` must be an x9.62-encoded FP256BN curve point:
+ * ( 0x04 | pub_key.x-coord | pub_key.y-coord )
+ *
  * Returns:
  * 0 on success
  * -1 on failure
  */
 int ecdaa_tpm_context_init_socket(struct ecdaa_tpm_context *tpm_ctx,
-                                  ECP_FP256BN *public_key_in,
+                                  const uint8_t *public_key_in,
                                   TPM_HANDLE key_handle_in,
                                   const char *hostname,
                                   const char *port,

--- a/src/tpm-utils/commit.c
+++ b/src/tpm-utils/commit.c
@@ -30,7 +30,7 @@ static
 void ecp_to_tpm_format(TPM2B_ECC_POINT *tpm_out, ECP_FP256BN *point_in);
 
 static
-int ecp_to_amcl_format(ECP_FP256BN *point_out, TPM2B_ECC_POINT *tpm_in);
+int tpm_to_amcl_format(ECP_FP256BN *point_out, TPM2B_ECC_POINT *tpm_in);
 
 int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
                ECP_FP256BN *P1,
@@ -104,7 +104,7 @@ int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
                 ret = -2;
                 break;
             }
-            if (0 != ecp_to_amcl_format(K, &K_tpm)) {
+            if (0 != tpm_to_amcl_format(K, &K_tpm)) {
                 ret = -2;
                 break;
             }
@@ -114,7 +114,7 @@ int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
                 ret = -2;
                 break;
             }
-            if (0 != ecp_to_amcl_format(L, &L_tpm)) {
+            if (0 != tpm_to_amcl_format(L, &L_tpm)) {
                 ret = -2;
                 break;
             }
@@ -124,7 +124,7 @@ int tpm_commit(struct ecdaa_tpm_context *tpm_ctx,
                 ret = -2;
                 break;
             }
-            if (0 != ecp_to_amcl_format(E, &E_tpm)) {
+            if (0 != tpm_to_amcl_format(E, &E_tpm)) {
                 ret = -2;
                 break;
             }
@@ -157,7 +157,7 @@ void ecp_to_tpm_format(TPM2B_ECC_POINT *tpm_out, ECP_FP256BN *point_in)
     BIG_256_56_toBytes((char*)tpm_out->point.y.buffer, y);
 }
 
-int ecp_to_amcl_format(ECP_FP256BN *point_out, TPM2B_ECC_POINT *tpm_in)
+int tpm_to_amcl_format(ECP_FP256BN *point_out, TPM2B_ECC_POINT *tpm_in)
 {
     if (tpm_in->point.x.size==0 || tpm_in->point.y.size==0)
         return -2;

--- a/src/tpm_context.c
+++ b/src/tpm_context.c
@@ -31,13 +31,13 @@ static TSS2_SYS_CONTEXT* sapi_ctx_init(const char* hostname,
                                        size_t memory_pool_size);
 
 static int tpm_context_init_common(struct ecdaa_tpm_context *tpm_ctx,
-                                   ECP_FP256BN *public_key_in,
+                                   const uint8_t *public_key_in,
                                    TPM_HANDLE key_handle_in,
                                    const char *password,
                                    uint16_t password_length);
 
 int ecdaa_tpm_context_init_socket(struct ecdaa_tpm_context *tpm_ctx,
-                                  ECP_FP256BN *public_key_in,
+                                  const uint8_t *public_key_in,
                                   TPM_HANDLE key_handle_in,
                                   const char *hostname,
                                   const char *port,
@@ -104,7 +104,7 @@ sapi_ctx_init(const char *hostname,
 }
 
 int tpm_context_init_common(struct ecdaa_tpm_context *tpm_ctx,
-                            ECP_FP256BN *public_key_in,
+                            const uint8_t *public_key_in,
                             TPM_HANDLE key_handle_in,
                             const char *key_password,
                             uint16_t key_password_length)
@@ -114,7 +114,7 @@ int tpm_context_init_common(struct ecdaa_tpm_context *tpm_ctx,
 
     tpm_ctx->commit_counter = UINT16_MAX;
 
-    ECP_FP256BN_copy(&tpm_ctx->public_key, public_key_in);
+    ecp_FP256BN_deserialize(&tpm_ctx->public_key, (uint8_t*)public_key_in);
 
     tpm_ctx->key_handle = key_handle_in;
 


### PR DESCRIPTION
To work toward avoiding AMCL knowledge in the user, the `tpm_context_init` function should take its public key input in the well-known x9.62 encoding, and not as an AMCL `ECP` struct.

This arose during usage of the `ecdaa-python` wrapper, where we need to create a `tpm_context` struct but don't have access to AMCL functions for creating the necessary `ECP` public key point.

To fully avoid `AMCL` knowledge in the API, we also need to add "add" and "remove" (and serialization) functionality to the `revocations` struct, but that's TODO.