### PR TITLE
Fix bls383

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   global:
     - LIBSODIUM_DIR=${TRAVIS_BUILD_DIR}/libsodium
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
-    - ECDAA_CURVES=FP256BN,BN254
+    - ECDAA_CURVES=FP256BN,BN254,BN254CX,BLS383
     - CFLAGS=-I${LIBSODIUM_DIR}/include/
     - LDFLAGS=-L${LIBSODIUM_DIR}/lib/
     - LD_LIBRARY_PATH=${LIBSODIUM_DIR}/lib/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.6.0")
+        VERSION "0.6.1")
 
 include(GNUInstallDirs)
 include(CTest)

--- a/src/amcl-extensions/ecp_ZZZ.c
+++ b/src/amcl-extensions/ecp_ZZZ.c
@@ -104,8 +104,16 @@ int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t me
         BIG_XXX x;
         big_XXX_from_two_message_hash(&x, (uint8_t*)&i, sizeof(i), message, message_length);
         BIG_XXX_mod(x, curve_order);
-        if (ECP_ZZZ_setx(point_out, x, 0))
+        // Check if generated point is on curve:
+        if (ECP_ZZZ_setx(point_out, x, 0)) {
+            // If on curve, and cofactor != 1, multiply by cofactor to get on correct subgroup.
+            BIG_XXX cofactor;
+            BIG_XXX_rcopy(cofactor, CURVE_Cof_ZZZ);
+            if (!BIG_XXX_isunity(cofactor)) {
+                ECP_ZZZ_mul(point_out, cofactor);
+            }
             return i;
+        }
     }
 
     // If we reach here, we ran out of tries, so return error.

--- a/src/internal/schnorr_ZZZ.c
+++ b/src/internal/schnorr_ZZZ.c
@@ -154,7 +154,7 @@ int schnorr_verify_ZZZ(BIG_XXX c,
         if (hash_ret < 0)
             return -1;
 
-        // 2ii) Multiply P2 by s (L = s*P)
+        // 2ii) Multiply P2 by s (L = s*P2)
         ECP_ZZZ_copy(&L, &P2);
         ECP_ZZZ_mul(&L, s);
 
@@ -166,7 +166,7 @@ int schnorr_verify_ZZZ(BIG_XXX c,
         // 4) Compute difference of L and c*K, and save to L (L = s*P2 - c*K)
         ECP_ZZZ_sub(&L, &K_c);
 
-        // c' = Hash( R | basepoint | public_key | L | P2 | K_out | basename | msg_in )
+        // c' = Hash( R | basepoint | public_key | L | P2 | K | basename | msg_in )
         uint8_t hash_input_begin[SIX_ECP_LENGTH];
         assert(6*ECP_ZZZ_LENGTH == sizeof(hash_input_begin));
         ecp_ZZZ_serialize(hash_input_begin, &R);


### PR DESCRIPTION
Tests using BLS383 were failing, when verifying signatures created using a basename.

The root of the issue is that the `ecp_BLS383_fromhash` function needs to multiply the generated point by the cofactor of the curve group (in order to put the point in the proper subgroup of the full curve group).

For the other curves, this didn't arise, because their cofactors are 1. BLS383, though, has a rather large cofactor.