### PR TITLE
Bring back the formerly-breaking part of tpm-test.

### DIFF
--- a/.travis/run-tpm-simulator.sh
+++ b/.travis/run-tpm-simulator.sh
@@ -26,4 +26,4 @@ tpm_sim_host=localhost
 
 ${xaptum_tpm_dir}/.travis/install-ibm-tpm2.sh ${tpm_sim_dir}
 ${xaptum_tpm_dir}/.travis/run-ibm-tpm2.sh ${tpm_sim_dir}
-${xaptum_tpm_dir}/build/testBin/tss2_sys_createprimary-test "${tpm_sim_host}" "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"
+${xaptum_tpm_dir}/build/testBin/create_load_evict-test "${tpm_sim_host}" "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"


### PR DESCRIPTION
This also means to use the child-signing-key executable from xaptum-tpm in travis.
For the simulator it makes no difference (this test never broke against
the simulator).
But, this is the way to do it if running against an actual Infineon TPM
(with the broken firmware).