### PR TITLE
Fix verify with basenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ to the `verify` command.
 If the signature is valid, this command returns success.
 
 ```bash
-verify message.bin sig.bin gpk.bin sk_revocation_list.bin num-sks-in-sk_revocation_list
+verify message.bin sig.bin gpk.bin sk_revocation_list.bin num-sks-in-sk_revocation_list bsn_revocation_list.bin num_bsns-in-bsn_revocation_list basename.bin
 ```
 
 # Algorithm

--- a/examples/member_sign.c
+++ b/examples/member_sign.c
@@ -110,8 +110,15 @@ int main(int argc, char *argv[])
     }
 
     // Write signature to file
-    ecdaa_signature_FP256BN_serialize(buffer, &sig, basename_len != 0);
-    if (ECDAA_SIGNATURE_FP256BN_LENGTH != write_buffer_to_file(args.sig_out_file, buffer, ECDAA_SIGNATURE_FP256BN_LENGTH)) {
+    int has_nym = basename_len != 0;
+    uint32_t sig_length;
+    if (has_nym) {
+        sig_length = ECDAA_SIGNATURE_FP256BN_WITH_NYM_LENGTH;
+    } else {
+        sig_length = ECDAA_SIGNATURE_FP256BN_LENGTH;
+    }
+    ecdaa_signature_FP256BN_serialize(buffer, &sig, has_nym);
+    if ((int)sig_length != write_buffer_to_file(args.sig_out_file, buffer, sig_length)) {
         fprintf(stderr, "Error writing signature to file: \"%s\"\n", args.sig_out_file);
         return 1;
     }

--- a/examples/verify.c
+++ b/examples/verify.c
@@ -179,16 +179,10 @@ int parse_args(struct command_line_args *args_out, int argc, char *argv[])
 
         args_out->sk_rev_list_file = argv[4];
         int num_revs_in = atoi(argv[5]);
-        if (0 == num_revs_in) {
-            fprintf(stderr, "Warning: Bad value for <number-of-secret-key-revocations-in-list>: %s\nUsing 0\n", argv[5]);
-        }
         args_out->number_of_sk_revs = (unsigned)num_revs_in;
 
         args_out->bsn_rev_list_file = argv[6];
         int num_bsn_revs_in = atoi(argv[7]);
-        if (0 == num_revs_in) {
-            fprintf(stderr, "Warning: Bad value for <number-of-basename-signature-revocations-in-list>: %s\nUsing 0\n", argv[7]);
-        }
         args_out->number_of_bsn_revs = (unsigned)num_bsn_revs_in;
 
         args_out->basename_file = NULL;

--- a/examples/verify.c
+++ b/examples/verify.c
@@ -79,13 +79,20 @@ int main(int argc, char *argv[])
     }
 
     // Read signature from disk
+    int has_nym = basename_len != 0;
+    uint32_t sig_length;
+    if (has_nym) {
+        sig_length = ECDAA_SIGNATURE_FP256BN_WITH_NYM_LENGTH;
+    } else {
+        sig_length = ECDAA_SIGNATURE_FP256BN_LENGTH;
+    }
     struct ecdaa_signature_FP256BN sig;
-    if (ECDAA_SIGNATURE_FP256BN_LENGTH != read_file_into_buffer(buffer, ECDAA_SIGNATURE_FP256BN_LENGTH, args.sig_file)) {
+    if ((int)sig_length != read_file_into_buffer(buffer, sig_length, args.sig_file)) {
         fprintf(stderr, "Error reading signature file: \"%s\"\n", args.sig_file);
         ret = 1;
         goto cleanup;
     }
-    if (0 != ecdaa_signature_FP256BN_deserialize(&sig, buffer, basename_len != 0)) {
+    if (0 != ecdaa_signature_FP256BN_deserialize(&sig, buffer, has_nym)) {
         fputs("Error deserializing signature\n", stderr);
         ret = 1;
         goto cleanup;
@@ -114,7 +121,8 @@ int main(int argc, char *argv[])
     // Read in bsn_rev_list from disk.
     if (0 != parse_bsn_rev_list_file(&revocations, args.bsn_rev_list_file, args.number_of_bsn_revs)) {
         fputs("Error parsing basename-signature revocation list file\n", stderr);
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
     // Read message from disk.
@@ -139,6 +147,8 @@ int main(int argc, char *argv[])
 cleanup:
     if (NULL != revocations.sk_list) {
         free(revocations.sk_list);
+    }
+    if (NULL != revocations.bsn_list) {
         free(revocations.bsn_list);
     }
 


### PR DESCRIPTION
Irina found an issue with the verification example, when using a basename file.

The issue is that the signature isn't getting (de)serialized properly in the case of a basename-enabled signature.