### PR TITLE
Fix find xaptum tpm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.6.1")
+        VERSION "0.6.2")
 set(PROJECT_VERSION_PACKAGE_REVISION 2)
 
 include(GNUInstallDirs)

--- a/cmake/FindXaptumTPM.cmake
+++ b/cmake/FindXaptumTPM.cmake
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License
 
-if (NOT TARGET xaptum-tpm)
+if (NOT TARGET xaptumtpm)
         if (NOT XAPTUM_TPM_LOCAL_DIR)
                 set(XAPTUM_TPM_LOCAL_DIR "${CMAKE_CURRENT_LIST_DIR}/../xaptum-tpm")
         endif (NOT XAPTUM_TPM_LOCAL_DIR)
@@ -28,4 +28,4 @@ if (NOT TARGET xaptum-tpm)
         set(XAPTUM_TPM_LIBRARIES ${XAPTUM_TPM_LIBRARY})
 
         set(XAPTUM_TPM_FOUND TRUE)
-endif (NOT TARGET xaptum-tpm)
+endif (NOT TARGET xaptumtpm)


### PR DESCRIPTION
The guards int eh `FindXaptumTPM.cmake` that ensure we only find XaptumTPM once were incorrect, meaning Xaptum-TPM would *never* be properly found! Things were only working because the `xaptum-tpm` directory was in the default location, I guess.