### PR TITLE
Fix bin location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.6.2")
+        VERSION "0.6.3")
 set(PROJECT_VERSION_PACKAGE_REVISION 3)
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,9 @@ else()
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDISABLE_LIBSODIUM_RNG_SEED_FUNCTION")
 endif()
 
-set(GENERATED_TOPLEVEL_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include")
+set(TOPLEVEL_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+set(GENERATED_TOPLEVEL_INCLUDE_DIR "${TOPLEVEL_BINARY_DIR}/include")
 
 file(GLOB PUBLIC_HEADERS "include/ecdaa/*.h")
 file(GLOB_RECURSE IMPLEMENTATION_H_FILES "src/*.h")
@@ -101,7 +103,7 @@ foreach(template_file ${FILES_TO_PROCESS})
         execute_process(COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/template_expansion.py
                                         --template ${template_file}
                                         --curves ${ECDAA_CURVES}
-                                        --out-dir ${CMAKE_BINARY_DIR}
+                                        --out-dir ${TOPLEVEL_BINARY_DIR}
                                         --top-level-dir ${CMAKE_CURRENT_SOURCE_DIR}
                                         --names-only
                 OUTPUT_VARIABLE processed_file_names)
@@ -110,7 +112,7 @@ foreach(template_file ${FILES_TO_PROCESS})
                 COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/template_expansion.py
                                 --template ${template_file}
                                 --curves ${ECDAA_CURVES}
-                                --out-dir ${CMAKE_BINARY_DIR}
+                                --out-dir ${TOPLEVEL_BINARY_DIR}
                                 --top-level-dir ${CMAKE_CURRENT_SOURCE_DIR}
                 DEPENDS ${template_file})
 
@@ -125,7 +127,7 @@ add_custom_target(toplevel_header
         COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/template_expansion.py
                         --template ${CMAKE_CURRENT_SOURCE_DIR}/include/ecdaa.h 
                         --curves ${ECDAA_CURVES}
-                        --out-dir ${CMAKE_BINARY_DIR}
+                        --out-dir ${TOPLEVEL_BINARY_DIR}
                         --top-level-dir ${CMAKE_CURRENT_SOURCE_DIR}
                         --top-level-header
                         ${USE_TPM_PYTHON_OPTION})
@@ -232,7 +234,7 @@ if(BUILD_EXAMPLES)
         add_subdirectory(examples)
 
         if(NOT BUILD_SHARED_LIBS)
-                install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/ DESTINATION ${CMAKE_INSTALL_BINDIR})
+                install(PROGRAMS ${TOPLEVEL_BINARY_DIR}/bin/ DESTINATION ${CMAKE_INSTALL_BINDIR})
         endif()
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 add_definitions("-Wno-unused-function")
 
-set(CURRENT_PROGRAMS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/)
+set(CURRENT_PROGRAMS_BINARY_DIR ${TOPLEVEL_BINARY_DIR}/bin/)
 
 set(ECDAA_PROGRAM_MAIN_FILES
         ecdaa_extract_group_public_key.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(expand_test_case template_file)
         execute_process(COMMAND python3 ${PROJECT_SOURCE_DIR}/cmake/template_expansion.py
                                         --template ${template_file}
                                         --curves ${ECDAA_CURVES}
-                                        --out-dir ${CMAKE_BINARY_DIR}
+                                        --out-dir ${TOPLEVEL_BINARY_DIR}
                                         --top-level-dir ${PROJECT_SOURCE_DIR}
                                         --names-only
                 OUTPUT_VARIABLE processed_file_names)
@@ -27,7 +27,7 @@ macro(expand_test_case template_file)
                 COMMAND python3 ${PROJECT_SOURCE_DIR}/cmake/template_expansion.py
                                 --template ${template_file}
                                 --curves ${ECDAA_CURVES}
-                                --out-dir ${CMAKE_BINARY_DIR}
+                                --out-dir ${TOPLEVEL_BINARY_DIR}
                                 --top-level-dir ${PROJECT_SOURCE_DIR}
                 DEPENDS ${template_file})
 
@@ -52,7 +52,7 @@ macro(add_test_case case_file)
           PRIVATE ${XAPTUM_TPM_INCLUDE_DIRS}
           PRIVATE ${GENERATED_TOPLEVEL_INCLUDE_DIR}
           PRIVATE ${PROJECT_SOURCE_DIR}/include/ecdaa/
-          PRIVATE ${CMAKE_BINARY_DIR}/
+          PRIVATE ${TOPLEVEL_BINARY_DIR}/
           )
 
   set_target_properties(${case_name} PROPERTIES
@@ -64,7 +64,7 @@ macro(add_test_case case_file)
           )
 endmacro()
 
-set(CURRENT_TEST_BINARY_DIR ${CMAKE_BINARY_DIR}/testBin/)
+set(CURRENT_TEST_BINARY_DIR ${TOPLEVEL_BINARY_DIR}/testBin/)
 
 file(GLOB_RECURSE ECDAA_TEST_FILES "*.c")
 
@@ -76,14 +76,14 @@ if(NOT ECDAA_TPM_SUPPORT)
                 endif()
         endforeach()
 else()
-        file(COPY tpm-test-utils.h DESTINATION ${CMAKE_BINARY_DIR}/test/)
+        file(COPY tpm-test-utils.h DESTINATION ${TOPLEVEL_BINARY_DIR}/test/)
 endif()
 
 foreach(template_file ${ECDAA_TEST_FILES})
         expand_test_case(${template_file})
 endforeach()
 
-file(COPY ecdaa-test-utils.h DESTINATION ${CMAKE_BINARY_DIR}/test/)
+file(COPY ecdaa-test-utils.h DESTINATION ${TOPLEVEL_BINARY_DIR}/test/)
 
 foreach(case_file ${ECDAA_TEST_SRCS})
         add_test_case(${case_file})
@@ -92,4 +92,4 @@ endforeach()
 # Add the integration-tests python script
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/integration-tests.py ${CURRENT_TEST_BINARY_DIR}/integration-tests.py)
 add_test(NAME integration-tests
-        COMMAND python "${CURRENT_TEST_BINARY_DIR}/integration-tests.py" "${CMAKE_BINARY_DIR}/bin/")
+        COMMAND python "${CURRENT_TEST_BINARY_DIR}/integration-tests.py" "${TOPLEVEL_BINARY_DIR}/bin/")


### PR DESCRIPTION
Previously, if this project were included as a sub_directory of a higher-level CMake project, we would spray our output all over their build directory, rather than into our own directory.