### PR TITLE
Dont run integration tests unless BUILD_EXAMPLES=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.6.3")
+        VERSION "0.6.4")
 set(PROJECT_VERSION_PACKAGE_REVISION 3)
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ modify the installation location.
 
 ## Running the tests
 
-The tests assume that the `-DBUILD_EXAMPLES=ON` CMake option was used during building.
-
 ```bash
 cd build
 ctest -V
 ```
+
+NOTE: If the `-DBUILD_EXAMPLES=ON` CMake option was not set, the "integration-tests"
+will NOT be run.
 
 ### Testing TPM support
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,8 @@ foreach(case_file ${ECDAA_TEST_SRCS})
 endforeach()
 
 # Add the integration-tests python script
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/integration-tests.py ${CURRENT_TEST_BINARY_DIR}/integration-tests.py)
-add_test(NAME integration-tests
-        COMMAND python "${CURRENT_TEST_BINARY_DIR}/integration-tests.py" "${TOPLEVEL_BINARY_DIR}/bin/")
+if(BUILD_EXAMPLES)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/integration-tests.py ${CURRENT_TEST_BINARY_DIR}/integration-tests.py)
+        add_test(NAME integration-tests
+                COMMAND python "${CURRENT_TEST_BINARY_DIR}/integration-tests.py" "${TOPLEVEL_BINARY_DIR}/bin/")
+endif()


### PR DESCRIPTION
Since `BUILD_EXAMPLES` is OFF by default, if someone stock builds this project and then tries to run `ctest`, they'll see integration-tests fail.

So, don't run integration-tests, unless we have the examples.