### PR TITLE
Improve tpm api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,8 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.6.4")
-set(PROJECT_VERSION_PACKAGE_REVISION 3)
+        VERSION "0.7.0")
+set(PROJECT_VERSION_PACKAGE_REVISION 1)
 
 include(GNUInstallDirs)
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ cmake --build .
 In addition to the standard CMake options the following configuration
 options and variables are supported.
 
+### TPM Support
+
+By default, the library builds with support for using a TPM.
+If this isn't desired, set the `cmake` option `ECDAA_TPM_SUPPORT=Off`.
+
 ### Static vs Shared Libary
 If `BUILD_SHARED_LIBS` is set, the shared library is built. If
 `BUILD_STATIC_LIBS` is set, the static library is built. If both are
@@ -148,6 +153,14 @@ and its public key (in x9.62 format) and TPM handle (as a hex-formatted integer)
 must be available in the text files
 `build/test/pub_key.txt` and `build/test/handle.txt`, respectively.
 
+If using a local `xaptum-tpm` repo,
+a quick way to set up a TPM2.0 simulator with the required settings,
+in order to run the `ecdaa` tests,
+is to run:
+```
+.travis/run-tpm-simulator.sh ${ABSOLUTE_PATH_TO_XAPTUM_TPM_PROJECT} $(pwd)/build/ibm-simulator $(pwd)/build/test
+```
+
 # Usage
 
 The only header that has to be included is `ecdaa.h`.
@@ -192,9 +205,6 @@ where `credential` is an ECDAA credential obtained earlier and `prng` is an `ecd
 
 Notice that the signature thus created is not TPM-specific.
 This means that verification of a TPM-generated signature proceeds as usual, using `ecdaa_signature_FP256BN_verify`.
-
-By default, the library builds with support for using a TPM.
-If this isn't desired, set the `cmake` option `ECDAA_TPM_SUPPORT=Off`.
 
 ## Random number generator
 

--- a/include/ecdaa/member_keypair_TPM.h
+++ b/include/ecdaa/member_keypair_TPM.h
@@ -35,6 +35,7 @@ extern "C" {
  * -1 on error
  */
 int ecdaa_member_key_pair_TPM_generate(struct ecdaa_member_public_key_FP256BN *pk_out,
+                                       const uint8_t *serialized_public_key_in,
                                        uint8_t *nonce,
                                        uint32_t nonce_length,
                                        struct ecdaa_tpm_context *tpm_ctx);

--- a/include/ecdaa/tpm_context.h
+++ b/include/ecdaa/tpm_context.h
@@ -36,7 +36,6 @@ struct ecdaa_tpm_context {
     uint8_t context_buffer[TPM_CONTEXT_BUFFER_SIZE];
 
     TSS2_SYS_CONTEXT *sapi_context;
-    ECP_FP256BN public_key; 
     uint16_t commit_counter;
     TPM_HANDLE key_handle;
 
@@ -56,15 +55,11 @@ struct ecdaa_tpm_context {
  *
  * Only password authentication (for the ownership of the Schnorr keypair) is supported.
  *
- * `public_key_in` must be an x9.62-encoded FP256BN curve point:
- * ( 0x04 | pub_key.x-coord | pub_key.y-coord )
- *
  * Returns:
  * 0 on success
  * -1 on failure
  */
 int ecdaa_tpm_context_init_socket(struct ecdaa_tpm_context *tpm_ctx,
-                                  const uint8_t *public_key_in,
                                   TPM_HANDLE key_handle_in,
                                   const char *hostname,
                                   const char *port,

--- a/src/member_keypair_TPM.c
+++ b/src/member_keypair_TPM.c
@@ -24,14 +24,16 @@
 #include <assert.h>
 
 int ecdaa_member_key_pair_TPM_generate(struct ecdaa_member_public_key_FP256BN *pk,
+                                       const uint8_t *serialized_public_key_in,
                                        uint8_t *nonce,
                                        uint32_t nonce_length,
                                        struct ecdaa_tpm_context *tpm_ctx)
 {
     int ret = 0;
 
-    // 1) Copy public key from TPM.
-    ECP_FP256BN_copy(&pk->Q, &tpm_ctx->public_key);
+    // 1) Copy public key
+    if (0 != ecp_FP256BN_deserialize(&pk->Q, (uint8_t*)serialized_public_key_in))
+        return -1;
 
     // 2) and a Schnorr-type signature on the Schnorr-type public_key itself concatenated with the nonce.
     ECP_FP256BN basepoint;

--- a/src/tpm_context.c
+++ b/src/tpm_context.c
@@ -31,24 +31,22 @@ static TSS2_SYS_CONTEXT* sapi_ctx_init(const char* hostname,
                                        size_t memory_pool_size);
 
 static int tpm_context_init_common(struct ecdaa_tpm_context *tpm_ctx,
-                                   const uint8_t *public_key_in,
                                    TPM_HANDLE key_handle_in,
                                    const char *password,
                                    uint16_t password_length);
 
 int ecdaa_tpm_context_init_socket(struct ecdaa_tpm_context *tpm_ctx,
-                                  const uint8_t *public_key_in,
                                   TPM_HANDLE key_handle_in,
                                   const char *hostname,
                                   const char *port,
-                                  const char *password,
-                                  uint16_t password_length)
+                                  const char *key_password,
+                                  uint16_t key_password_length)
 {
     tpm_ctx->sapi_context = sapi_ctx_init(hostname, port, tpm_ctx->context_buffer, sizeof(tpm_ctx->context_buffer));
     if (NULL == tpm_ctx->sapi_context)
         return -1;
 
-    if (0 != tpm_context_init_common(tpm_ctx, public_key_in, key_handle_in, password, password_length))
+    if (0 != tpm_context_init_common(tpm_ctx, key_handle_in, key_password, key_password_length))
         return -1;
 
     return 0;
@@ -104,7 +102,6 @@ sapi_ctx_init(const char *hostname,
 }
 
 int tpm_context_init_common(struct ecdaa_tpm_context *tpm_ctx,
-                            const uint8_t *public_key_in,
                             TPM_HANDLE key_handle_in,
                             const char *key_password,
                             uint16_t key_password_length)
@@ -113,9 +110,6 @@ int tpm_context_init_common(struct ecdaa_tpm_context *tpm_ctx,
         return -1;
 
     tpm_ctx->commit_counter = UINT16_MAX;
-
-    if (0 != ecp_FP256BN_deserialize(&tpm_ctx->public_key, (uint8_t*)public_key_in))
-        return -1;
 
     tpm_ctx->key_handle = key_handle_in;
 

--- a/test/schnorr_TPM-tests.c
+++ b/test/schnorr_TPM-tests.c
@@ -60,7 +60,7 @@ void full_test()
                            msg,
                            msg_len,
                            &G1,
-                           &ctx.tpm_ctx.public_key,
+                           &ctx.public_key,
                            NULL,
                            0,
                            &ctx.tpm_ctx);
@@ -69,7 +69,7 @@ void full_test()
         TEST_ASSERT(0==1);
     }
 
-    ret = schnorr_verify_FP256BN(c, s, NULL, msg, msg_len, &G1, &ctx.tpm_ctx.public_key, NULL, 0);
+    ret = schnorr_verify_FP256BN(c, s, NULL, msg, msg_len, &G1, &ctx.public_key, NULL, 0);
     if (0 != ret) {
         printf("Error in schnorr_verify_TPM, ret=%d, tpm_rc=0x%x\n", ret, ctx.tpm_ctx.last_return_code);
         TEST_ASSERT(0==1);
@@ -107,7 +107,7 @@ static void schnorr_TPM_basename()
                            msg,
                            msg_len,
                            &G1,
-                           &ctx.tpm_ctx.public_key,
+                           &ctx.public_key,
                            basename,
                            basename_len,
                            &ctx.tpm_ctx);
@@ -116,7 +116,7 @@ static void schnorr_TPM_basename()
         TEST_ASSERT(0==1);
     }
 
-    TEST_ASSERT(0 == schnorr_verify_FP256BN(c, s, &K, msg, msg_len, &G1, &ctx.tpm_ctx.public_key, basename, basename_len));
+    TEST_ASSERT(0 == schnorr_verify_FP256BN(c, s, &K, msg, msg_len, &G1, &ctx.public_key, basename, basename_len));
 
     tpm_cleanup(&ctx);
 
@@ -152,7 +152,7 @@ static void schnorr_TPM_wrong_basename_fails()
                            msg,
                            msg_len,
                            &G1,
-                           &ctx.tpm_ctx.public_key,
+                           &ctx.public_key,
                            basename,
                            basename_len,
                            &ctx.tpm_ctx);
@@ -161,7 +161,7 @@ static void schnorr_TPM_wrong_basename_fails()
         TEST_ASSERT(0==1);
     }
 
-    TEST_ASSERT(0 != schnorr_verify_FP256BN(c, s, &K, msg, msg_len, &G1, &ctx.tpm_ctx.public_key, wrong_basename, wrong_basename_len));
+    TEST_ASSERT(0 != schnorr_verify_FP256BN(c, s, &K, msg, msg_len, &G1, &ctx.public_key, wrong_basename, wrong_basename_len));
 
     tpm_cleanup(&ctx);
 

--- a/test/signature_TPM-tests.c
+++ b/test/signature_TPM-tests.c
@@ -83,7 +83,7 @@ static void setup(sign_and_verify_fixture* fixture)
 
     uint8_t *nonce = (uint8_t*)"nonce";
     uint32_t nonce_len = 5;
-    TEST_ASSERT(0 == ecdaa_member_key_pair_TPM_generate(&fixture->pk, nonce, nonce_len, &fixture->tpm_ctx.tpm_ctx));
+    TEST_ASSERT(0 == ecdaa_member_key_pair_TPM_generate(&fixture->pk, fixture->tpm_ctx.serialized_public_key, nonce, nonce_len, &fixture->tpm_ctx.tpm_ctx));
 
     struct ecdaa_credential_FP256BN_signature cred_sig;
     ecdaa_credential_FP256BN_generate(&fixture->cred, &cred_sig, &fixture->isk, &fixture->pk, &fixture->prng);

--- a/test/tpm-test-utils.h
+++ b/test/tpm-test-utils.h
@@ -28,6 +28,8 @@ int read_public_key_from_files(uint8_t *public_key,
 
 struct tpm_test_context {
     struct ecdaa_tpm_context tpm_ctx;
+    uint8_t serialized_public_key[ECP_FP256BN_LENGTH];
+    ECP_FP256BN public_key;
 };
 
 static
@@ -40,15 +42,19 @@ int tpm_initialize(struct tpm_test_context *ctx)
 
     int ret = 0;
 
-    uint8_t public_key[ECP_FP256BN_LENGTH];
     TPM_HANDLE key_handle = 0;
 
-    if (0 != read_public_key_from_files(public_key, &key_handle, pub_key_filename, handle_filename)) {
+    if (0 != read_public_key_from_files(ctx->serialized_public_key, &key_handle, pub_key_filename, handle_filename)) {
         printf("Error: error reading in public key files '%s' and '%s'\n", pub_key_filename, handle_filename);
         return -1;
     }
 
-    ret = ecdaa_tpm_context_init_socket(&ctx->tpm_ctx, public_key, key_handle, hostname, port, NULL, 0);
+    if (0 != ecp_FP256BN_deserialize(&ctx->public_key, (uint8_t*)ctx->serialized_public_key)) {
+        printf("Error: error public key to point\n");
+        return -1;
+    }
+
+    ret = ecdaa_tpm_context_init_socket(&ctx->tpm_ctx, key_handle, hostname, port, NULL, 0);
     if (0 != ret) {
         printf("Error: ecdaa_tpm_context_init failed: 0x%x\n", ret);
         return -1;

--- a/test/tpm-test.c
+++ b/test/tpm-test.c
@@ -297,8 +297,8 @@ void one_hash_returns_commitment_plus_priv_key()
     fflush(stdout);
 
     ECP_FP256BN_mul(&G1, s);
-    ECP_FP256BN_mul(&ctx.tpm_ctx.public_key, c);
-    ECP_FP256BN_sub(&G1, &ctx.tpm_ctx.public_key);
+    ECP_FP256BN_mul(&ctx.public_key, c);
+    ECP_FP256BN_sub(&G1, &ctx.public_key);
     ECP_FP256BN_affine(&G1);
     printf("[s]G1 - c*pub_key={");
     uint8_t g1_buf[ECP_FP256BN_LENGTH];


### PR DESCRIPTION
Don't require the serialized public key to create a `tpm_context`.
Instead, require the serialized public key in order to create a `member_key_pair_TPM` (that's where it's actually needed).

Also, improve README on how to run tests using the TPM simulator.