### PR TITLE
Fix random mod order collision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,8 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.7.0")
-set(PROJECT_VERSION_PACKAGE_REVISION 2)
+        VERSION "0.7.1")
+set(PROJECT_VERSION_PACKAGE_REVISION 1)
 
 include(GNUInstallDirs)
 include(CTest)

--- a/src/amcl-extensions/big_XXX.c
+++ b/src/amcl-extensions/big_XXX.c
@@ -113,15 +113,6 @@ void big_XXX_mod_mul_and_add(BIG_XXX *big_out,
     BIG_XXX_mod(*big_out, modulus);
 }
 
-void big_XXX_random_mod_order(BIG_XXX *big_out,
-                              csprng *rng)
-{
-    BIG_XXX curve_order;
-    BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
-
-    BIG_XXX_randomnum(*big_out, curve_order, rng);
-}
-
 static void convert_hash_to_big_XXX(BIG_XXX *big_out, hash256 *hash)
 {
     char hash_as_bytes[32] = {0};

--- a/src/amcl-extensions/big_XXX.h
+++ b/src/amcl-extensions/big_XXX.h
@@ -75,15 +75,6 @@ void big_XXX_mod_mul_and_add(BIG_XXX *big_out,
                              BIG_XXX multiplicand2,
                              BIG_XXX modulus);
 
-/*
- * Generate a uniformly-distributed pseudo-random number,
- * between [0, n], where n is the order of the EC group.
- *
- * Output is normalized.
- */
-void big_XXX_random_mod_order(BIG_XXX *big_out,
-                              csprng *rng);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/amcl-extensions/ecp_ZZZ.c
+++ b/src/amcl-extensions/ecp_ZZZ.c
@@ -119,3 +119,13 @@ int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t me
     // If we reach here, we ran out of tries, so return error.
     return -1;
 }
+
+void ecp_ZZZ_random_mod_order(BIG_XXX *big_out,
+                              csprng *rng)
+{
+    BIG_XXX curve_order;
+    BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
+
+    BIG_XXX_randomnum(*big_out, curve_order, rng);
+}
+

--- a/src/amcl-extensions/ecp_ZZZ.h
+++ b/src/amcl-extensions/ecp_ZZZ.h
@@ -74,6 +74,15 @@ int ecp_ZZZ_deserialize(ECP_ZZZ *point_out,
  */
 int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t message_length);
 
+/*
+ * Generate a uniformly-distributed pseudo-random number,
+ * between [0, n], where n is the order of the EC group.
+ *
+ * Output is normalized.
+ */
+void ecp_ZZZ_random_mod_order(BIG_XXX *big_out,
+                              csprng *rng);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/credential_ZZZ.c
+++ b/src/credential_ZZZ.c
@@ -20,7 +20,6 @@
 
 #include "./internal/schnorr_ZZZ.h"
 #include "./internal/explicit_bzero.h"
-#include "./amcl-extensions/big_XXX.h"
 #include "./amcl-extensions/ecp_ZZZ.h"
 #include "./amcl-extensions/ecp2_ZZZ.h"
 #include "./amcl-extensions/pairing_ZZZ.h"
@@ -53,7 +52,7 @@ int ecdaa_credential_ZZZ_generate(struct ecdaa_credential_ZZZ *cred,
 
     // 1) Choose random l <- Z_p
     BIG_XXX l;
-    big_XXX_random_mod_order(&l, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&l, get_csprng(prng));
 
     // 2) Multiply generator by l and save to cred->A (A = l*P)
     ecp_ZZZ_set_to_generator(&cred->A);

--- a/src/internal/randomize_credential_ZZZ.c
+++ b/src/internal/randomize_credential_ZZZ.c
@@ -18,7 +18,7 @@
 
 #include "randomize_credential_ZZZ.h"
 
-#include "../amcl-extensions/big_XXX.h"
+#include "../amcl-extensions/ecp_ZZZ.h"
 
 void randomize_credential_ZZZ(struct ecdaa_credential_ZZZ *cred,
                               struct ecdaa_prng *prng,
@@ -26,7 +26,7 @@ void randomize_credential_ZZZ(struct ecdaa_credential_ZZZ *cred,
 {
     // 1) Choose random l <- Z_p
     BIG_XXX l;
-    big_XXX_random_mod_order(&l, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&l, get_csprng(prng));
 
     // 2) Multiply the four points in the credential by l,
     //  and save to the four points in the signature

--- a/src/internal/schnorr_ZZZ.c
+++ b/src/internal/schnorr_ZZZ.c
@@ -52,7 +52,7 @@ void schnorr_keygen_ZZZ(ECP_ZZZ *public_out,
                         BIG_XXX *private_out,
                         struct ecdaa_prng *prng)
 {
-    big_XXX_random_mod_order(private_out, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(private_out, get_csprng(prng));
 
     ecp_ZZZ_set_to_generator(public_out);
 
@@ -215,7 +215,7 @@ int credential_schnorr_sign_ZZZ(BIG_XXX *c_out,
 
     // 2) Choose random r <- Z_n
     BIG_XXX r;
-    big_XXX_random_mod_order(&r, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&r, get_csprng(prng));
 
     // 3) Multiply generator by r: U = r*generator
     ECP_ZZZ U;
@@ -334,8 +334,8 @@ int issuer_schnorr_sign_ZZZ(BIG_XXX *c_out,
 
     // 2) Choose random rx, ry <- Z_n
     BIG_XXX rx, ry;
-    big_XXX_random_mod_order(&rx, get_csprng(prng));
-    big_XXX_random_mod_order(&ry, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&rx, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&ry, get_csprng(prng));
 
     // 3) Multiply generator_2 by rx: Ux = rx*generator_2
     ECP2_ZZZ Ux;
@@ -453,7 +453,7 @@ int commit(ECP_ZZZ *P1,
     //  which means it's valid.
 
     // 2) Choose random k <- Z_n
-    big_XXX_random_mod_order(k, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(k, get_csprng(prng));
 
     // 3) If s2 is provided,
     //  3i) Do K = [private_key](x2,y2),

--- a/src/issuer_keypair_ZZZ.c
+++ b/src/issuer_keypair_ZZZ.c
@@ -20,7 +20,7 @@
 
 #include <ecdaa/prng.h>
 
-#include "./amcl-extensions/big_XXX.h"
+#include "./amcl-extensions/ecp_ZZZ.h"
 #include "./amcl-extensions/ecp2_ZZZ.h"
 #include "./internal/schnorr_ZZZ.h"
 
@@ -40,8 +40,8 @@ int ecdaa_issuer_key_pair_ZZZ_generate(struct ecdaa_issuer_public_key_ZZZ *pk,
 {
     // Secret key is
     // two random Bignums.
-    big_XXX_random_mod_order(&sk->x, get_csprng(prng));
-    big_XXX_random_mod_order(&sk->y, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&sk->x, get_csprng(prng));
+    ecp_ZZZ_random_mod_order(&sk->y, get_csprng(prng));
 
     // Public key is
     // 1) G2 generator raised to the two private key random Bignums...

--- a/test/benchmarks_ZZZ.c
+++ b/test/benchmarks_ZZZ.c
@@ -69,16 +69,16 @@ static void setup(sign_and_verify_fixture* fixture)
 {
     TEST_ASSERT(0 == ecdaa_prng_init(&fixture->prng));
 
-    big_XXX_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.X);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.X, fixture->isk.x);
 
-    big_XXX_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.Y);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.Y, fixture->isk.y);
 
     ecp_ZZZ_set_to_generator(&fixture->pk.Q);
-    big_XXX_random_mod_order(&fixture->sk.sk, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->sk.sk, get_csprng(&fixture->prng));
     ECP_ZZZ_mul(&fixture->pk.Q, fixture->sk.sk);
 
     struct ecdaa_credential_ZZZ_signature cred_sig;

--- a/test/big_XXX-tests.c
+++ b/test/big_XXX-tests.c
@@ -20,8 +20,6 @@
 
 #include "src/amcl-extensions/big_XXX.h"
 
-#include <ecdaa/prng.h>
-
 #include <amcl/ecp_ZZZ.h>
 
 #include <stdio.h>
@@ -38,7 +36,6 @@ static void mul_and_add_modulus_two();
 static void mul_and_add_normalization_works();
 static void mul_and_add_greater_than_modulus_ok();
 static void mul_and_add_small_sanity_check();
-static void random_num_mod_order_is_valid();
 
 int main()
 {
@@ -53,7 +50,6 @@ int main()
     mul_and_add_normalization_works();
     mul_and_add_greater_than_modulus_ok();
     mul_and_add_small_sanity_check();
-    random_num_mod_order_is_valid();
 }
 
 void hash_not_zero()
@@ -313,27 +309,3 @@ void mul_and_add_small_sanity_check()
     printf("\tsuccess\n");
 }
 
-void random_num_mod_order_is_valid()
-{
-    printf("Starting pairing_curve_utils::random_num_mod_order_is_valid...\n");
-
-    BIG_XXX curve_order;
-    BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
-
-    struct ecdaa_prng prng;
-    TEST_ASSERT(0 == ecdaa_prng_init(&prng));
-
-    BIG_XXX num;
-    for (int i = 0; i < 500; ++i) {
-        big_XXX_random_mod_order(&num, get_csprng(&prng));
-
-        TEST_ASSERT(BIG_XXX_iszilch(num) == 0);
-        TEST_ASSERT(BIG_XXX_isunity(num) == 0);
-
-        TEST_ASSERT(BIG_XXX_comp(num, curve_order) == -1);
-    }
-
-    ecdaa_prng_free(&prng);
-
-    printf("\tsuccess\n");
-}

--- a/test/credential_ZZZ-tests.c
+++ b/test/credential_ZZZ-tests.c
@@ -60,16 +60,16 @@ static void setup(credential_test_fixture* fixture)
 {
     TEST_ASSERT(0 == ecdaa_prng_init(&fixture->prng));
 
-    big_XXX_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.X);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.X, fixture->isk.x);
 
-    big_XXX_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.Y);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.Y, fixture->isk.y);
 
     ecp_ZZZ_set_to_generator(&fixture->pk.Q);
-    big_XXX_random_mod_order(&fixture->sk.sk, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->sk.sk, get_csprng(&fixture->prng));
     ECP_ZZZ_mul(&fixture->pk.Q, fixture->sk.sk);
 }
 

--- a/test/member_keypair_ZZZ-tests.c
+++ b/test/member_keypair_ZZZ-tests.c
@@ -151,7 +151,7 @@ static void serialize_deserialize_secret()
     TEST_ASSERT(0 == ecdaa_prng_init(&prng));
 
     struct ecdaa_member_secret_key_ZZZ sk;
-    big_XXX_random_mod_order(&sk.sk, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&sk.sk, get_csprng(&prng));
 
     uint8_t buffer[ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH];
     ecdaa_member_secret_key_ZZZ_serialize(buffer, &sk);
@@ -172,7 +172,7 @@ static void serialize_deserialize_public_no_check()
     TEST_ASSERT(0 == ecdaa_prng_init(&prng));
 
     BIG_XXX sk;
-    big_XXX_random_mod_order(&sk, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&sk, get_csprng(&prng));
 
     struct ecdaa_member_public_key_ZZZ pk;
     ecp_ZZZ_set_to_generator(&pk.Q);

--- a/test/schnorr_ZZZ-tests.c
+++ b/test/schnorr_ZZZ-tests.c
@@ -97,7 +97,7 @@ void schnorr_sign_sane()
     ECP_ZZZ public;
     BIG_XXX private;
 
-    big_XXX_random_mod_order(&private, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&private, get_csprng(&prng));
     ecp_ZZZ_set_to_generator(&public);
 
     ECP_ZZZ_mul(&public, private);
@@ -249,12 +249,12 @@ void schnorr_sign_integration_other_basepoint()
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
     BIG_XXX rand;
-    big_XXX_random_mod_order(&rand, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&rand, get_csprng(&prng));
     ECP_ZZZ_mul(&basepoint, rand);
 
     ECP_ZZZ public;
     BIG_XXX private;
-    big_XXX_random_mod_order(&private, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&private, get_csprng(&prng));
     ECP_ZZZ_copy(&public, &basepoint);
     ECP_ZZZ_mul(&public, private);
 
@@ -352,10 +352,10 @@ void schnorr_credential_sign_sane()
     struct ecdaa_prng prng;
     TEST_ASSERT(0 == ecdaa_prng_init(&prng));
 
-    big_XXX_random_mod_order(&credential_random, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&credential_random, get_csprng(&prng));
 
-    big_XXX_random_mod_order(&member_private, get_csprng(&prng));
-    big_XXX_random_mod_order(&issuer_private, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&member_private, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&issuer_private, get_csprng(&prng));
     ecp_ZZZ_set_to_generator(&member_public);
     ECP_ZZZ_mul(&member_public, member_private);
 
@@ -416,9 +416,9 @@ void schnorr_issuer_sign_sane()
     TEST_ASSERT(0 == ecdaa_prng_init(&prng));
 
     BIG_XXX issuer_private_x;
-    big_XXX_random_mod_order(&issuer_private_x, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&issuer_private_x, get_csprng(&prng));
     BIG_XXX issuer_private_y;
-    big_XXX_random_mod_order(&issuer_private_y, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&issuer_private_y, get_csprng(&prng));
     ECP2_ZZZ issuer_public_X;
     ECP2_ZZZ issuer_public_Y;
     ecp2_ZZZ_set_to_generator(&issuer_public_X);
@@ -450,13 +450,13 @@ void schnorr_issuer_sign_integration()
     TEST_ASSERT(0 == ecdaa_prng_init(&prng));
 
     BIG_XXX issuer_private_x;
-    big_XXX_random_mod_order(&issuer_private_x, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&issuer_private_x, get_csprng(&prng));
     ECP2_ZZZ issuer_public_X;
     ecp2_ZZZ_set_to_generator(&issuer_public_X);
     ECP2_ZZZ_mul(&issuer_public_X, issuer_private_x);
 
     BIG_XXX issuer_private_y;
-    big_XXX_random_mod_order(&issuer_private_y, get_csprng(&prng));
+    ecp_ZZZ_random_mod_order(&issuer_private_y, get_csprng(&prng));
     ECP2_ZZZ issuer_public_Y;
     ecp2_ZZZ_set_to_generator(&issuer_public_Y);
     ECP2_ZZZ_mul(&issuer_public_Y, issuer_private_y);

--- a/test/signature_TPM-tests.c
+++ b/test/signature_TPM-tests.c
@@ -73,11 +73,11 @@ static void setup(sign_and_verify_fixture* fixture)
 
     TEST_ASSERT(0 == ecdaa_prng_init(&fixture->prng));
 
-    big_256_56_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
+    ecp_FP256BN_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
     ecp2_FP256BN_set_to_generator(&fixture->ipk.gpk.X);
     ECP2_FP256BN_mul(&fixture->ipk.gpk.X, fixture->isk.x);
 
-    big_256_56_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
+    ecp_FP256BN_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
     ecp2_FP256BN_set_to_generator(&fixture->ipk.gpk.Y);
     ECP2_FP256BN_mul(&fixture->ipk.gpk.Y, fixture->isk.y);
 

--- a/test/signature_ZZZ-tests.c
+++ b/test/signature_ZZZ-tests.c
@@ -78,16 +78,16 @@ static void setup(sign_and_verify_fixture* fixture)
 {
     TEST_ASSERT(0 == ecdaa_prng_init(&fixture->prng));
 
-    big_XXX_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->isk.x, get_csprng(&fixture->prng));
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.X);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.X, fixture->isk.x);
 
-    big_XXX_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->isk.y, get_csprng(&fixture->prng));
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.Y);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.Y, fixture->isk.y);
 
     ecp_ZZZ_set_to_generator(&fixture->pk.Q);
-    big_XXX_random_mod_order(&fixture->sk.sk, get_csprng(&fixture->prng));
+    ecp_ZZZ_random_mod_order(&fixture->sk.sk, get_csprng(&fixture->prng));
     ECP_ZZZ_mul(&fixture->pk.Q, fixture->sk.sk);
 
     struct ecdaa_credential_ZZZ_signature cred_sig;

--- a/test/tpm-test.c
+++ b/test/tpm-test.c
@@ -173,7 +173,7 @@ void zero_hash_returns_commitment()
     struct ecdaa_prng prng;
     TEST_ASSERT(0 == ecdaa_prng_init(&prng));
     BIG_256_56 exp;
-    big_256_56_random_mod_order(&exp, get_csprng(&prng));
+    ecp_FP256BN_random_mod_order(&exp, get_csprng(&prng));
     ECP_FP256BN_mul(&G1, exp);
     ret = tpm_commit(&ctx.tpm_ctx, &G1, NULL, 0, &K, &L, &E);
     if (0 != ret) {


### PR DESCRIPTION
Make `random_mod_order` part of ecp extensions, not big extensions.

That function depends on the order of the specific curve, not just the
type of BIGNUM being used. Thus, we need a different function for each
curve, not just each big.

Having just one for each big was causing linking problems (we really need separate functions, but since they were getting named the same thing they were clobbering each other).