### PR TITLE
Add xaptum tpm dev dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(ecdaa
         LANGUAGES C
         VERSION "0.7.1")
-set(PROJECT_VERSION_PACKAGE_REVISION 1)
+set(PROJECT_VERSION_PACKAGE_REVISION 2)
 
 include(GNUInstallDirs)
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ if( UNIX )
 
         set(ECDAA_DEPENDS_STRING "libsodium(>=1.0.13)")
         if(NOT BUILD_SHARED_LIBS)
-                set(ECDAA_DEPENDS_STRING "${ECDAA_DEPENDS_STRING}, amcl(>= 4.1.1)")
+                set(ECDAA_DEPENDS_STRING "${ECDAA_DEPENDS_STRING}, amcl(>= 4.1.1), xaptum-tpm-dev(>=0.3.0)")
         endif()
         set(CPACK_DEBIAN_PACKAGE_DEPENDS ${ECDAA_DEPENDS_STRING})
 


### PR DESCRIPTION
The `ecdaa-dev` package requires `xaptum-tpm` header files, so add a dependency on the `xaptum-tpm-dev` package.