### PR TITLE
Clarify a comment about how we hash into a G1 curve point.

### DIFF
--- a/src/amcl-extensions/ecp_ZZZ.c
+++ b/src/amcl-extensions/ecp_ZZZ.c
@@ -105,6 +105,7 @@ int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t me
         big_XXX_from_two_message_hash(&x, (uint8_t*)&i, sizeof(i), message, message_length);
         BIG_XXX_mod(x, curve_order);
         // Check if generated point is on curve:
+        //  (the 0 indicates we want the y-coord with lsb=0)
         if (ECP_ZZZ_setx(point_out, x, 0)) {
             // If on curve, and cofactor != 1, multiply by cofactor to get on correct subgroup.
             BIG_XXX cofactor;

--- a/src/amcl-extensions/ecp_ZZZ.h
+++ b/src/amcl-extensions/ecp_ZZZ.h
@@ -60,13 +60,14 @@ int ecp_ZZZ_deserialize(ECP_ZZZ *point_out,
 /*
  * Hash a message into an ECP_ZZZ point.
  *
- * The curve point generated from the message m is found as follows (cf. Chen and Li, 2013):
+ * The curve point generated from the message m is found as follows
+ *      (cf. "Hunting and Pecking with ECC Groups" in Dragonfly spec):
  *  1. Set i := 0 be a 32-bit unsigned integer.
  *  2. Compute x := H(i, m).
  *  3. Compute z := x**3 + ax + b mod q.
  *  4. Compute y := sqrt(z) mod q. If y does not exist, set i := i + 1,
  *      repeat step 2 if i < 232, otherwise, report failure.
- *  5. Set y := min(y, q - y).
+ *  5. Set y to whichever of {y, q - y} has lowest-order bit equal to 0.
  *
  * Returns:
  *  i on success (i is 32-bit unsigned integer used in construction above)


### PR DESCRIPTION
The previous comment said we were using the algorithm of Chen and Li,
but that actually chooses the minimum of the two possible y-coords
(we're taking a modular square root, so we have two choices).
In reality, the AMCL function we're using makes the choice based on
least-significant bit.
Maybe these are the same (lsb=0 <=> minimum), but I don't know.
So, just make sure we're clear.