### PR TITLE
cmake: fix default local dir in find_package scripts

### DIFF
--- a/cmake/FindAMCL.cmake
+++ b/cmake/FindAMCL.cmake
@@ -14,7 +14,7 @@
 
 if (NOT TARGET amcl)
         if (NOT AMCL_LOCAL_DIR)
-                set(AMCL_LOCAL_DIR "${CMAKE_CURRENT_LIST_DIR}/../milagro-crypto-c/install/")
+                set(AMCL_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../milagro-crypto-c/build")
         endif (NOT AMCL_LOCAL_DIR)
 
         if (NOT FORCE_SYSTEM_AMCL_LIB)

--- a/cmake/FindXaptumTPM.cmake
+++ b/cmake/FindXaptumTPM.cmake
@@ -14,7 +14,7 @@
 
 if (NOT TARGET xaptumtpm)
         if (NOT XAPTUM_TPM_LOCAL_DIR)
-                set(XAPTUM_TPM_LOCAL_DIR "${CMAKE_CURRENT_LIST_DIR}/../xaptum-tpm")
+                set(XAPTUM_TPM_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../xaptum-tpm")
         endif (NOT XAPTUM_TPM_LOCAL_DIR)
 
         if (NOT FORCE_SYSTEM_XAPTUM_TPM_LIB)


### PR DESCRIPTION
In the Find*.cmake files, the default directory for local builds of
AMCL and xaptum-tpm is specified relative to the ecdaa repo directory
(not the cmake/ subdirectory). So use CMAKE_CURRENT_SOURCE_DIR, not
CMAKE_CURRENT_LIST_DIR.

Also, assume a consistent `build/` subdirectory for the build
directory of the dependencies.  FindAMCL.cmake assumed `install/` and
FindXaptumTPM.cmake assumed `build/`.