### PR TITLE
Move out tcti

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.7.2")
+        VERSION "0.8.0")
 set(PROJECT_VERSION_PACKAGE_REVISION 1)
 
 include(GNUInstallDirs)

--- a/include/ecdaa/tpm_context.h
+++ b/include/ecdaa/tpm_context.h
@@ -51,7 +51,9 @@ struct ecdaa_tpm_context {
 };
 
 /*
- * Initialize an ecdaa_tpm_context object and connect to a TPM listening on a TCP socket.
+ * Initialize an ecdaa_tpm_context object.
+ *
+ * The given TSS2_TCTI_CONTEXT is assumed to point to valid memory and already be initialized.
  *
  * Only password authentication (for the ownership of the Schnorr keypair) is supported.
  *
@@ -59,12 +61,11 @@ struct ecdaa_tpm_context {
  * 0 on success
  * -1 on failure
  */
-int ecdaa_tpm_context_init_socket(struct ecdaa_tpm_context *tpm_ctx,
-                                  TPM_HANDLE key_handle_in,
-                                  const char *hostname,
-                                  const char *port,
-                                  const char *key_password,
-                                  uint16_t key_password_length);
+int ecdaa_tpm_context_init(struct ecdaa_tpm_context *tpm_ctx,
+                           TPM_HANDLE key_handle_in,
+                           const char *key_password,
+                           uint16_t key_password_length,
+                           TSS2_TCTI_CONTEXT *tcti_context);
 
 void ecdaa_tpm_context_free(struct ecdaa_tpm_context *tpm_ctx);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,10 +40,10 @@ macro(add_test_case case_file)
   add_executable(${case_name} ${case_file})
 
   if(BUILD_SHARED_LIBS)
-          target_link_libraries(${case_name} PRIVATE ecdaa ${AMCL_LIBRARIES} ${ECDAA_SEED_LINK_LIBRARY})
+          target_link_libraries(${case_name} PRIVATE ecdaa ${AMCL_LIBRARIES} ${ECDAA_SEED_LINK_LIBRARY} ${XAPTUM_TPM_LIBRARIES})
           add_dependencies(${case_name} ecdaa)
   else()
-          target_link_libraries(${case_name} PRIVATE ecdaa_static ${AMCL_LIBRARIES} ${ECDAA_SEED_LINK_LIBRARY})
+          target_link_libraries(${case_name} PRIVATE ecdaa_static ${AMCL_LIBRARIES} ${ECDAA_SEED_LINK_LIBRARY} ${XAPTUM_TPM_LIBRARIES})
           add_dependencies(${case_name} ecdaa_static)
   endif()
 


### PR DESCRIPTION
Take a pointer to a TCTI context when initializing a tpm_context, rather than initializing the TCTI context internally.

This allows us to be agnostic about whether it's a TCP socket, or dev file, or whatever.