### PR TITLE
Decrease required version of libsodium, from 1.0.13 to 1.0.11.

### DIFF
--- a/.travis/install-libsodium.sh
+++ b/.travis/install-libsodium.sh
@@ -18,11 +18,11 @@ if [[ $# -ne 1 ]]; then
         exit 1
 fi
 
-version=1.0.13
+version=1.0.11
 source_dir="$1"
 mkdir -p ${source_dir}
 pushd ${source_dir}
-wget https://download.libsodium.org/libsodium/releases/libsodium-${version}.tar.gz
+wget https://download.libsodium.org/libsodium/releases/old/libsodium-${version}.tar.gz
 tar xvfz libsodium-${version}.tar.gz
 pushd libsodium-${version}
 ./configure --prefix=${INSTALL_PREFIX}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pseudonym linking ("basename signatures") is optional, and secret-key revocation
 - milagro-crypto-c
   - The milagro library must be built with support for the necessary curves
   - Currently, the fork available [here](https://github.com/drbild/milagro-crypto-c/tree/fix-cmake) must be used
-- libsodium >= 1.0.13
+- libsodium >= 1.0.11
   - Optionally, see below
 - xaptum-tpm >= 0.4.0
   - If building with TPM support


### PR DESCRIPTION
We had required 1.0.13 earlier, because that was the most-up-to-date
at that time.
However, Debian 9 ships with 1.0.11, so it would be nice to only require
that high.
Luckily, building with 1.0.11 works.