### PR TITLE
Ensure that limits.h is included in prng.c, even when not using sodium

### DIFF
--- a/src/prng.c
+++ b/src/prng.c
@@ -20,6 +20,8 @@
 
 #include "internal/explicit_bzero.h"
 
+#include <limits.h>
+
 #ifndef DISABLE_LIBSODIUM_RNG_SEED_FUNCTION
 
 #include <sodium.h>
@@ -30,8 +32,6 @@
 #include <sys/ioctl.h>
 #include <linux/random.h>
 #endif
-
-#include <limits.h>
 
 static int check_entropy()
 {


### PR DESCRIPTION
Note, in the course of creating this commit, I discovered that setting `DISABLE_LIBSODIUM_RNG_SEED_FUNCTION` keeps essentially all of the tests from compiling.

So, currently, this commit can't be tested. 

This issue will be fixed in the upcoming work to update how we take randomness (issue #96).