### PR TITLE
Install examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ list(APPEND CMAKE_MODULE_PATH CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmak
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.8.3")
+        VERSION "0.8.4")
 
 include(GNUInstallDirs)
 include(CTest)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,7 +43,5 @@ foreach(main_file ${ECDAA_PROGRAM_MAIN_FILES})
                 RUNTIME_OUTPUT_DIRECTORY ${CURRENT_PROGRAMS_BINARY_DIR}
         )
 
-        if(NOT BUILD_SHARED_LIBS)
-                install(TARGETS ${program_name} DESTINATION ${CMAKE_INSTALL_BINDIR})
-        endif()
+        install(TARGETS ${program_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach(main_file ${ECDAA_PROGRAM_MAIN_FILES})


### PR DESCRIPTION
We were still wrapping the CMake install call for the examples in a `if (NOT BUILD_SHARED_LIBS)`.