### PR TITLE
Be careful comparing CMake strings to empty, in Findsodium

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ list(APPEND CMAKE_MODULE_PATH CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmak
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.8.4")
+        VERSION "0.8.5")
 
 include(GNUInstallDirs)
 include(CTest)

--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -66,13 +66,13 @@ if (UNIX)
 
         # if pkgconfig for libsodium doesn't provide
         # static lib info, then override PKG_STATIC here..
-        if (sodium_PKG_STATIC_LIBRARIES STREQUAL "")
+        if (NOT DEFINED sodium_PKG_STATIC_LIBRARIES OR sodium_PKG_STATIC_LIBRARIES STREQUAL "")
             set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
         endif()
 
         set(XPREFIX sodium_PKG_STATIC)
     else()
-        if (sodium_PKG_LIBRARIES STREQUAL "")
+        if (NOT DEFINED sodium_PKG_LIBRARIES OR sodium_PKG_LIBRARIES STREQUAL "")
             set(sodium_PKG_LIBRARIES sodium)
         endif()
 


### PR DESCRIPTION
Findsodium uses the following to see if the user has specified the name of the sodium libraries (I don't know why it allows that, but it does):
`if (sodium_LIBRARIES STREQUAL "")`
If this is true, then it sets it to the reasonable default `sodium`.

The problem is that if `sodium_LIBRARIES` is not even set, then this is untrue, so `sodium_LIBRARIES` never gets set, and we call `find_library` on an unset variable (and thus never find that library).

This fixes that by explicitly augmenting that check to
`if (NOT DEFINED sodium_LIBRARIES OR sodium_LIBRARIES STREQUAL "")`