### PR TITLE
Set compiler flags (e.g. -std= and -Werror) as add_compile_options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(ECDAA_TPM_SUPPORT)
   find_package(xaptum-tpm 0.5.0 REQUIRED QUIET)
 endif()
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wextra -std=c99 -Wno-missing-field-initializers")
+add_compile_options(-std=c99 -Werror -Wall -Wextra -Wno-missing-field-initializers)
 SET(CMAKE_C_FLAGS_DEBUGWITHCOVERAGE "${CMAKE_C_FLAGS_DEBUGWITHCOVERAGE} -O0 -fprofile-arcs -ftest-coverage")
 SET(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-add_definitions("-Wno-unused-function")
+add_compile_options("-Wno-unused-function")
 
 set(CURRENT_PROGRAMS_BINARY_DIR ${TOPLEVEL_BINARY_DIR}/bin/)
 


### PR DESCRIPTION
This is to avoid polluting the global variables