### PR TITLE
Benchmark and test reorganization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ include(DetermineWordSize)
 option(BUILD_SHARED_LIBS "Build as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build as a static library" OFF)
 
+option(BUILD_BENCHMARKS "Build benchmarks" ON)
+
 # If not building as a shared library, force build as a static.  This
 # is to match the CMake default semantics of using
 # BUILD_SHARED_LIBS = OFF to indicate a static build.
@@ -133,6 +135,13 @@ endif()
 ################################################################################
 if (BUILD_TESTING)
         add_subdirectory(test)
+endif()
+
+################################################################################
+# Benchmarks
+################################################################################
+if (BUILD_BENCHMARKS)
+        add_subdirectory(benchmarks)
 endif()
 
 ################################################################################

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright 2017 Xaptum, Inc.
+# 
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+# 
+#        http://www.apache.org/licenses/LICENSE-2.0
+# 
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License
+
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+macro(add_benchmark case_file)
+  get_filename_component(case_name ${case_file} NAME_WE)
+
+  add_executable(${case_name} ${case_file} $<TARGET_OBJECTS:ecdaa_utilities>)
+
+  if(BUILD_SHARED_LIBS)
+          target_link_libraries(${case_name} PRIVATE
+                                ecdaa)
+  else()
+          target_link_libraries(${case_name} PRIVATE
+                                ecdaa_static)
+  endif()
+
+  target_include_directories(${case_name}
+          PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                  $<BUILD_INTERFACE:${ECDAA_INTERNAL_UTILITIES_INCLUDE_DIR}>
+                  ${TOPLEVEL_BINARY_DIR}/libecdaa
+  )
+
+  set_target_properties(${case_name} PROPERTIES
+          RUNTIME_OUTPUT_DIRECTORY ${CURRENT_BENCHMARKS_BINARY_DIR}
+  )
+endmacro()
+
+set(CURRENT_BENCHMARKS_BINARY_DIR ${TOPLEVEL_BINARY_DIR}/benchmarksBin/)
+
+set(ECDAA_BENCHMARKS_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks_ZZZ.c
+)
+
+foreach(template_file ${ECDAA_BENCHMARKS_FILES})
+        expand_template(${template_file} ECDAA_BENCHMARKS_SRCS FALSE)
+endforeach()
+
+foreach(benchmark ${ECDAA_BENCHMARKS_SRCS})
+        add_benchmark(${benchmark})
+endforeach()

--- a/benchmarks/benchmarks_ZZZ.c
+++ b/benchmarks/benchmarks_ZZZ.c
@@ -16,7 +16,7 @@
  *
  *****************************************************************************/
 
-#include "ecdaa-test-utils.h"
+#include "ecdaa-benchmark-utils.h"
 
 #include "schnorr/schnorr_ZZZ.h"
 #include "amcl-extensions/big_XXX.h"
@@ -66,20 +66,20 @@ int main()
 
 static void setup(sign_and_verify_fixture* fixture)
 {
-    ecp_ZZZ_random_mod_order(&fixture->isk.x, test_randomness);
+    ecp_ZZZ_random_mod_order(&fixture->isk.x, benchmark_randomness);
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.X);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.X, fixture->isk.x);
 
-    ecp_ZZZ_random_mod_order(&fixture->isk.y, test_randomness);
+    ecp_ZZZ_random_mod_order(&fixture->isk.y, benchmark_randomness);
     ecp2_ZZZ_set_to_generator(&fixture->ipk.gpk.Y);
     ECP2_ZZZ_mul(&fixture->ipk.gpk.Y, fixture->isk.y);
 
     ecp_ZZZ_set_to_generator(&fixture->pk.Q);
-    ecp_ZZZ_random_mod_order(&fixture->sk.sk, test_randomness);
+    ecp_ZZZ_random_mod_order(&fixture->sk.sk, benchmark_randomness);
     ECP_ZZZ_mul(&fixture->pk.Q, fixture->sk.sk);
 
     struct ecdaa_credential_ZZZ_signature cred_sig;
-    ecdaa_credential_ZZZ_generate(&fixture->cred, &cred_sig, &fixture->isk, &fixture->pk, test_randomness);
+    ecdaa_credential_ZZZ_generate(&fixture->cred, &cred_sig, &fixture->isk, &fixture->pk, benchmark_randomness);
 
     fixture->msg = (uint8_t*) "Test message";
     fixture->msg_len = strlen((char*)fixture->msg);
@@ -107,7 +107,7 @@ void schnorr_sign_benchmark()
     ECP_ZZZ public;
     BIG_XXX private;
 
-    schnorr_keygen_ZZZ(&public, &private, test_randomness);
+    schnorr_keygen_ZZZ(&public, &private, benchmark_randomness);
 
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
@@ -120,7 +120,7 @@ void schnorr_sign_benchmark()
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
     for (unsigned i = 0; i < rounds; i++) {
-        schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness);
+        schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, benchmark_randomness);
     }
 
     struct timeval tv2;
@@ -148,7 +148,7 @@ static void sign_benchmark()
     gettimeofday(&tv1, NULL);
 
     for (unsigned i = 0; i < rounds; i++) {
-        TEST_ASSERT(0 == ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len, &fixture.sk, &fixture.cred, test_randomness));
+        BENCHMARK_ASSERT(0 == ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len, &fixture.sk, &fixture.cred, benchmark_randomness));
     }
 
     struct timeval tv2;
@@ -174,13 +174,13 @@ static void verify_benchmark()
 
     struct ecdaa_signature_ZZZ sig;
 
-    TEST_ASSERT(0 == ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len, &fixture.sk, &fixture.cred, test_randomness));
+    BENCHMARK_ASSERT(0 == ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len, &fixture.sk, &fixture.cred, benchmark_randomness));
 
     struct timeval tv1;
     gettimeofday(&tv1, NULL);
 
     for (unsigned i = 0; i < rounds; i++) {
-        TEST_ASSERT(0 == ecdaa_signature_ZZZ_verify(&sig, &fixture.ipk.gpk, &fixture.revocations, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len));
+        BENCHMARK_ASSERT(0 == ecdaa_signature_ZZZ_verify(&sig, &fixture.ipk.gpk, &fixture.revocations, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len));
     }
 
     struct timeval tv2;

--- a/benchmarks/ecdaa-benchmark-utils.h
+++ b/benchmarks/ecdaa-benchmark-utils.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *
+ * Copyright 2017-2018 Xaptum, Inc.
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#define BENCHMARK_ASSERT(cond) \
+    do \
+    { \
+        if (!(cond)) { \
+            printf("Condition \'%s\' failed\n\tin file: \'%s\'\n\tin function: \'%s\'\n\tat line: %d\n", #cond,__FILE__,  __func__, __LINE__); \
+            printf("exiting"); \
+            exit(1); \
+        } \
+    } while(0);
+
+void benchmark_randomness(void *buf, size_t buflen)
+{
+    // No need to worry about threading in these benchmarks
+    static FILE *file_ptr = NULL;
+    if (NULL == file_ptr)
+        file_ptr = fopen("/dev/urandom", "r");
+    BENCHMARK_ASSERT(file_ptr != NULL);
+
+    size_t read_ret = fread(buf, 1, buflen, file_ptr);
+    BENCHMARK_ASSERT(read_ret == buflen);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,6 @@ endmacro()
 set(CURRENT_TEST_BINARY_DIR ${TOPLEVEL_BINARY_DIR}/testBin/)
 
 set(ECDAA_TEST_FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks_ZZZ.c
         ${CMAKE_CURRENT_SOURCE_DIR}/big_XXX-tests.c
         ${CMAKE_CURRENT_SOURCE_DIR}/credential_ZZZ-tests.c
         ${CMAKE_CURRENT_SOURCE_DIR}/ecp2_ZZZ-tests.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 macro(add_test_case case_file)
   get_filename_component(case_name ${case_file} NAME_WE)
+  set(case_name "ecdaa-${case_name}")
 
   add_executable(${case_name} ${case_file} $<TARGET_OBJECTS:ecdaa_utilities>)
 
@@ -66,9 +67,9 @@ endforeach()
 
 # Add the integration-tests python script
 if(BUILD_EXAMPLES)
-        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/integration-tests.py ${CURRENT_TEST_BINARY_DIR}/integration-tests.py)
-        add_test(NAME integration-tests
-                COMMAND python "${CURRENT_TEST_BINARY_DIR}/integration-tests.py" "${TOPLEVEL_BINARY_DIR}/bin/")
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/integration-tests.py ${CURRENT_TEST_BINARY_DIR}/ecdaa-integration-tests.py)
+        add_test(NAME ecdaa-integration-tests
+                COMMAND python "${CURRENT_TEST_BINARY_DIR}/ecdaa-integration-tests.py" "${TOPLEVEL_BINARY_DIR}/bin/")
 endif()
 
 ################################################################################

--- a/test/tpm/CMakeLists.txt
+++ b/test/tpm/CMakeLists.txt
@@ -18,6 +18,7 @@ expand_template(${CMAKE_CURRENT_SOURCE_DIR}/tpm_ZZZ-test-utils.h ECDAA_TPM_UTILS
 
 macro(add_tpm_test_case case_file)
   get_filename_component(case_name ${case_file} NAME_WE)
+  set(case_name "ecdaa-${case_name}")
 
   add_executable(${case_name} ${case_file} $<TARGET_OBJECTS:ecdaa_utilities> ${ECDAA_TPM_UTILS_LIST})
 


### PR DESCRIPTION
This series

- moves the benchmarks into a separate folder behind a new `BUILD_BENCHMARKS` option
- adds an `ecdaa-` prefix to the tests

Both of these changes are motivated by projects that include `ecdaa` via `add_subdirectory`.  Most will not want to build or run the benchmarks (they take about 3.5 seconds on my machine) and will want the option of skipping `ecdaa` tests via `ctest -E ecdaa`.