### PR TITLE
Update signing algorithm to work with TPM spec 1.38 (and 1.16 with Errata 1.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ jobs:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
       - mkdir -p ${ECDAA_BUILD_DIR}
       - pushd ${ECDAA_BUILD_DIR}
-      - cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON
+      - cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON -DTEST_USE_TCP_TPM=ON
       - popd
     script:
       - pushd ${ECDAA_BUILD_DIR}
       - cmake --build . -- -j2
       - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${ECDAA_BUILD_DIR}/testBin ${TPM_KEY_DIR}
+      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
       - ctest -VV
       - popd
 
@@ -58,13 +58,13 @@ jobs:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
       - mkdir -p ${ECDAA_BUILD_DIR}
       - pushd ${ECDAA_BUILD_DIR}
-      - cmake .. -DCMAKE_BUILD_TYPE=DebugWithCoverage -DCMAKE_C_OUTPUT_EXTENSION_REPLACE=ON -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON
+      - cmake .. -DCMAKE_BUILD_TYPE=DebugWithCoverage -DCMAKE_C_OUTPUT_EXTENSION_REPLACE=ON -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON -DTEST_USE_TCP_TPM=ON
       - popd
     script:
       - pushd ${ECDAA_BUILD_DIR}
       - cmake --build . -- -j2
       - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${ECDAA_BUILD_DIR}/testBin ${TPM_KEY_DIR}
+      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
       - ctest -VV
       - popd
     after_success:
@@ -79,13 +79,13 @@ jobs:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
       - mkdir -p ${ECDAA_BUILD_DIR}
       - pushd ${ECDAA_BUILD_DIR}
-      - cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON
+      - cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON -DTEST_USE_TCP_TPM=ON
       - popd
     script:
       - pushd ${ECDAA_BUILD_DIR}
       - cmake --build . -- -j2
       - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${ECDAA_BUILD_DIR}/testBin ${TPM_KEY_DIR}
+      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
       - ctest -VV
       - popd
 
@@ -120,13 +120,13 @@ jobs:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
       - mkdir -p ${ECDAA_BUILD_DIR}
       - pushd ${ECDAA_BUILD_DIR}
-      - cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON
+      - cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON -DTEST_USE_TCP_TPM=ON
       - popd
     script:
       - pushd ${ECDAA_BUILD_DIR}
       - cmake --build . -- -j2
       - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${ECDAA_BUILD_DIR}/testBin ${TPM_KEY_DIR}
+      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
       - ctest -VV -E benchmarks -T memcheck
       - popd
     after_failure:
@@ -150,13 +150,13 @@ jobs:
       - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
       - mkdir -p ${ECDAA_BUILD_DIR}
       - pushd ${ECDAA_BUILD_DIR}
-      - cmake .. -DCMAKE_BUILD_TYPE=RelWithSanitize -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON
+      - cmake .. -DCMAKE_BUILD_TYPE=RelWithSanitize -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON -DTEST_USE_TCP_TPM=ON
       - popd
     script:
       - pushd ${ECDAA_BUILD_DIR}
       - cmake --build . -- -j2
       - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
-      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${ECDAA_BUILD_DIR}/testBin ${TPM_KEY_DIR}
+      - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
       - ctest -VV -E benchmarks
       - popd
 

--- a/.travis/install-ibm-tpm2.sh
+++ b/.travis/install-ibm-tpm2.sh
@@ -23,19 +23,11 @@ fi
 installation_dir="$1"
 
 if [[ ! -d "$installation_dir" ]]; then
-        git clone https://github.com/zanebeckwith/ibm-tpm2-simulator-mirror "$installation_dir"
+        git clone https://github.com/xaptum-eng/ibm-tpm2-simulator-mirror "$installation_dir"
 fi
 
 pushd $installation_dir 
 
-pushd ./tpm
 make
-popd
-
-pushd ./tss
-pushd ./utils/
-make
-popd
-popd
 
 popd

--- a/.travis/prepare-tpm2.sh
+++ b/.travis/prepare-tpm2.sh
@@ -16,11 +16,11 @@
 set -e
 
 if [[ $# -ne 2 ]]; then
-        echo "usage: $0 <absolute-path-to-test-binary-directory> <absolute-path-to-save-public-key>"
+        echo "usage: $0 <absolute-path-to-tpm-simulator-installation-directory> <absolute-path-to-save-public-key>"
         exit 1
 fi
 
-test_bin_dir="$1"
+installation_dir="$1"
 out_dir="$2"
 
-${test_bin_dir}/ecdaa-create_tpm_key-util "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"
+${installation_dir}/create_daa_key.sh "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"

--- a/.travis/prepare-tpm2.sh
+++ b/.travis/prepare-tpm2.sh
@@ -23,6 +23,4 @@ fi
 test_bin_dir="$1"
 out_dir="$2"
 
-tpm_sim_host=localhost
-
-${test_bin_dir}/ecdaa-create_tpm_key-util "${tpm_sim_host}" "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"
+${test_bin_dir}/ecdaa-create_tpm_key-util "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"

--- a/.travis/run-ibm-tpm2.sh
+++ b/.travis/run-ibm-tpm2.sh
@@ -26,14 +26,6 @@ pkill tpm_server || true
 
 pushd $installation_dir
 
-pushd tpm
-./tpm_server -rm &
-sleep 2
-popd
-
-pushd tss/utils/
-./powerup
-./startup
-popd
+./simulator.sh start
 
 popd

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ run the following steps:
 ``` bash
 .travis/install-ibm-tpm2.sh ./ibm-tpm2-simulator
 .travis/run-ibm-tpm2.sh ./ibm-tpm2-simulator/
-.travis/prepare-tpm2.sh ./build/testBin/ ./build/test/tpm
+.travis/prepare-tpm2.sh ./ibm-tpm2-simulator ./build/test/tpm
 ```
 
 The `ecdaa` tests will now be able to create signatures using the TPM2.0 simulator.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ If no `ECDAA_CURVES` is set, the default is to build `FP256BN`.
 
 ## Using a TPM
 
+This implementation has been tested against the following TCG TPM2.0 specifications:
+- Specification v1.38
+- Specification v1.16 with Errata v1.5
+
 Signatures can be created with the help of a Trusted Platform Module (TPM).
 
 To do so, a signing key must first be created and loaded in the TPM.
@@ -335,9 +339,12 @@ ecdaa_verify message.bin sig.bin gpk.bin sk_revocation_list.bin num-sks-in-sk_re
 
 The signature algorithm is that of
 [Camenisch et al., 2016](https://doi.org/10.1007/978-3-662-49387-8_10),
-with the exception that the "fix by Xi et al." discussed in Section 5.2 is NOT used
+with two exceptions:
+- The "fix by Xi et al." discussed in Section 5.2 is NOT used
 when creating TPM-enabled signatures (the current TPM2.0 specification doesn't allow
 such signatures to be created).
+- During signing, a random nonce is included in the message hash, as discussed in
+section 5.2.2 of [Camenisch et al., 2017](https://eprint.iacr.org/2017/639).
 
 # Testing and Analysis
 

--- a/README.md
+++ b/README.md
@@ -97,14 +97,20 @@ Running the integration tests requires `-DBUILD_EXAMPLES=ON`.
 
 #### Testing TPM support
 
+By default, the tests use a device-file-based TCTI.
+For this reason, `sudo` privileges may be required to run them.
+
+The tests can instead be built to use a TCP-socket-based TCTI,
+by using the CMake option `TEST_USE_TCP_TPM=ON`.
+
 The TPM tests require a [TPM 2.0
 simulator](https://sourceforge.net/projects/ibmswtpm2/) running
 locally on TCP port 2321.
 
-An ECDAA signing key must loaded in the simulator. The associated
+An ECDAA signing key must loaded in the TPM. The associated
 public key (in x9.62 format) and TPM handle (as a hex integer) must be
 in `build/test/tpm/pub_key.txt` and `build/test/tpm/handle.txt`.
-Currently, only the `TPM_ECC_NIST_P256` curve is supported in the tests.
+Currently, only the `TPM_ECC_BN_P256` curve is supported in the tests.
 
 Convenience scripts in the `.travis` directory can be used to download
 and prepare a TPM2.0 simulator for the tests.

--- a/benchmarks/benchmarks_ZZZ.c
+++ b/benchmarks/benchmarks_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -112,7 +112,7 @@ void schnorr_sign_benchmark()
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
 
     struct timeval tv1;
     gettimeofday(&tv1, NULL);
@@ -120,7 +120,7 @@ void schnorr_sign_benchmark()
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
     for (unsigned i = 0; i < rounds; i++) {
-        schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, benchmark_randomness);
+        schnorr_sign_ZZZ(&c, &s, &n, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, benchmark_randomness);
     }
 
     struct timeval tv2;

--- a/libecdaa-tpm/member_keypair_TPM_ZZZ.c
+++ b/libecdaa-tpm/member_keypair_TPM_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,7 @@ int ecdaa_member_key_pair_TPM_ZZZ_generate(struct ecdaa_member_public_key_ZZZ *p
     ecp_ZZZ_set_to_generator(&basepoint);
     ret = schnorr_sign_TPM_ZZZ(&pk->c,
                                &pk->s,
+                               &pk->n,
                                NULL,
                                nonce,
                                nonce_length,

--- a/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.h
+++ b/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,11 +37,13 @@ struct ecdaa_prng;
 /*
  * Perform TPM2_Commit/TPM2_Sign signature of msg_in, allowing for a non-standard basepoint.
  *
+ * n_out = RAND(Z_p)
  * if basename:
- *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | RAND(Z_p)*P2 | P2 | [private_key]P2 | basename | msg_in )
+ *  c = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | RAND(Z_p)*P2 | P2 | [private_key]P2 | basename | msg_in )
  *      where P2 = the curve point hashed from basename (cf. `ecp_ZZZ_fromhash`)
  * else:
- *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
+ *  c = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
+ * c_out = Hash ( n_out | c )
  * s_out = RAND(Z_p) + c_out * private_key,
  *
  * Note: All random numbers are chosen by the TPM.
@@ -56,6 +58,7 @@ struct ecdaa_prng;
  */
 int schnorr_sign_TPM_ZZZ(BIG_XXX *c_out,
                          BIG_XXX *s_out,
+                         BIG_XXX *n_out,
                          ECP_ZZZ *K_out,
                          const uint8_t *msg_in,
                          uint32_t msg_len,

--- a/libecdaa-tpm/signature_TPM_ZZZ.c
+++ b/libecdaa-tpm/signature_TPM_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,6 +47,7 @@ int ecdaa_signature_TPM_ZZZ_sign(struct ecdaa_signature_ZZZ *signature_out,
     //  where the basepoint is S.
     int sign_ret = schnorr_sign_TPM_ZZZ(&signature_out->c,
                                         &signature_out->s,
+                                        &signature_out->n,
                                         &signature_out->K,
                                         message,
                                         message_len,
@@ -55,7 +56,7 @@ int ecdaa_signature_TPM_ZZZ_sign(struct ecdaa_signature_ZZZ *signature_out,
                                         basename,
                                         basename_len,
                                         tpm_ctx);
-    
+
     return sign_ret;
 }
 

--- a/libecdaa/include/ecdaa/member_keypair_ZZZ.h
+++ b/libecdaa/include/ecdaa/member_keypair_ZZZ.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,9 +38,10 @@ struct ecdaa_member_public_key_ZZZ {
     ECP_ZZZ Q;
     BIG_XXX c;
     BIG_XXX s;
+    BIG_XXX n;
 };
 
-#define ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH ((2*MODBYTES_XXX + 1) + MODBYTES_XXX + MODBYTES_XXX)
+#define ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH ((2*MODBYTES_XXX + 1) + MODBYTES_XXX + MODBYTES_XXX + MODBYTES_XXX)
 size_t ecdaa_member_public_key_ZZZ_length(void);
 
 /*
@@ -68,7 +69,7 @@ int ecdaa_member_key_pair_ZZZ_generate(struct ecdaa_member_public_key_ZZZ *pk_ou
 
 /*
  * Check the signature on an `ecdaa_member_public_key_ZZZ`.
- * 
+ *
  * Returns:
  * 0 on success
  * -1 if signature is not valid.
@@ -81,7 +82,7 @@ int ecdaa_member_public_key_ZZZ_validate(struct ecdaa_member_public_key_ZZZ *pk,
  * Serialize an `ecdaa_member_public_key_ZZZ`
  *
  * The serialized format is:
- *  ( 0x04 | Q.x-coord | Q.y-coord | c | s )
+ *  ( 0x04 | Q.x-coord | Q.y-coord | c | s | n)
  *  where all numbers are zero-padded and in big-endian byte-order.
  *
  * The provided buffer is assumed to be large enough.
@@ -96,13 +97,13 @@ void ecdaa_member_public_key_ZZZ_serialize(uint8_t *buffer_out,
  *  provided by the Issuer when the Member generated this public key.
  *
  * The serialized format is expected to be:
- *  ( 0x04 | Q.x-coord | Q.y-coord | c | s )
+ *  ( 0x04 | Q.x-coord | Q.y-coord | c | s | n)
  *  where all numbers are zero-padded and in big-endian byte-order.
  *
  * Returns:
  * 0 on success
  * -1 if the format is incorrect
- * -2 if  (c,s) don't verify
+ * -2 if  (c,s,n) don't verify
  */
 int ecdaa_member_public_key_ZZZ_deserialize(struct ecdaa_member_public_key_ZZZ *pk_out,
                                             uint8_t *buffer_in,
@@ -113,7 +114,7 @@ int ecdaa_member_public_key_ZZZ_deserialize(struct ecdaa_member_public_key_ZZZ *
  * De-serialize an `ecdaa_member_public_key_ZZZ`, check its validity, but NOT its signature.
  *
  * The serialized format is expected to be:
- *  ( 0x04 | Q.x-coord | Q.y-coord | c | s )
+ *  ( 0x04 | Q.x-coord | Q.y-coord | c | s | n)
  *  where all numbers are zero-padded and in big-endian byte-order.
  *
  *  NOTE: The full public key (including the signature) is de-serialized,

--- a/libecdaa/include/ecdaa/signature_ZZZ.h
+++ b/libecdaa/include/ecdaa/signature_ZZZ.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,13 +44,14 @@ struct ecdaa_signature_ZZZ {
     ECP_ZZZ S;
     ECP_ZZZ T;
     ECP_ZZZ W;
+    BIG_XXX n;
     ECP_ZZZ K;
 };
 
-#define ECDAA_SIGNATURE_ZZZ_LENGTH (2*MODBYTES_XXX + 4*(2*MODBYTES_XXX + 1))
+#define ECDAA_SIGNATURE_ZZZ_LENGTH (3*MODBYTES_XXX + 4*(2*MODBYTES_XXX + 1))
 size_t ecdaa_signature_ZZZ_length(void);
 
-#define ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH (2*MODBYTES_XXX + 5*(2*MODBYTES_XXX + 1))
+#define ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH (3*MODBYTES_XXX + 5*(2*MODBYTES_XXX + 1))
 size_t ecdaa_signature_ZZZ_with_nym_length(void);
 
 /*
@@ -94,6 +95,7 @@ int ecdaa_signature_ZZZ_verify(struct ecdaa_signature_ZZZ *signature,
  *    0x04 | S.x-coord | S.y-coord |
  *    0x04 | T.x-coord | T.y-coord |
  *    0x04 | W.x-coord | W.y-coord |
+ *    n |
  *    0x04 | K.x-coord | K.y-coord ) <- If has_nym==1
  *
  * The provided buffer is assumed to be large enough.
@@ -111,6 +113,7 @@ void ecdaa_signature_ZZZ_serialize(uint8_t *buffer_out,
  *    0x04 | S.x-coord | S.y-coord |
  *    0x04 | T.x-coord | T.y-coord |
  *    0x04 | W.x-coord | W.y-coord |
+ *    n |
  *    0x04 | K.x-coord | K.y-coord ) <- If has_nym==1
  *
  *  NOTE: The four G1 points are checked as being on the curve,
@@ -133,6 +136,7 @@ int ecdaa_signature_ZZZ_deserialize(struct ecdaa_signature_ZZZ *signature_out,
  *    0x04 | S.x-coord | S.y-coord |
  *    0x04 | T.x-coord | T.y-coord |
  *    0x04 | W.x-coord | W.y-coord |
+ *    n |
  *    0x04 | K.x-coord | K.y-coord ) <- If has_nym==1
  *
  * Returns:

--- a/libecdaa/member_keypair_ZZZ.c
+++ b/libecdaa/member_keypair_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,6 +47,7 @@ int ecdaa_member_key_pair_ZZZ_generate(struct ecdaa_member_public_key_ZZZ *pk,
     ecp_ZZZ_set_to_generator(&basepoint);
     int sign_ret = schnorr_sign_ZZZ(&pk->c,
                                     &pk->s,
+                                    &pk->n,
                                     NULL,
                                     nonce,
                                     nonce_length,
@@ -65,11 +66,12 @@ int ecdaa_member_public_key_ZZZ_validate(struct ecdaa_member_public_key_ZZZ *pk,
                                          uint32_t nonce_length)
 {
     int ret = 0;
-    
+
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
     int sign_ret = schnorr_verify_ZZZ(pk->c,
                                       pk->s,
+                                      pk->n,
                                       NULL,
                                       nonce_in,
                                       nonce_length,
@@ -89,6 +91,7 @@ void ecdaa_member_public_key_ZZZ_serialize(uint8_t *buffer_out,
     ecp_ZZZ_serialize(buffer_out, &pk->Q);
     BIG_XXX_toBytes((char*)(buffer_out + ecp_ZZZ_length()), pk->c);
     BIG_XXX_toBytes((char*)(buffer_out + ecp_ZZZ_length() + MODBYTES_XXX), pk->s);
+    BIG_XXX_toBytes((char*)(buffer_out + ecp_ZZZ_length() + MODBYTES_XXX + MODBYTES_XXX), pk->n);
 }
 
 int ecdaa_member_public_key_ZZZ_deserialize(struct ecdaa_member_public_key_ZZZ *pk_out,
@@ -127,6 +130,7 @@ int ecdaa_member_public_key_ZZZ_deserialize_no_check(struct ecdaa_member_public_
     // 2) Deserialize the schnorr signature
     BIG_XXX_fromBytes(pk_out->c, (char*)(buffer_in + ecp_ZZZ_length()));
     BIG_XXX_fromBytes(pk_out->s, (char*)(buffer_in + ecp_ZZZ_length() + MODBYTES_XXX));
+    BIG_XXX_fromBytes(pk_out->n, (char*)(buffer_in + ecp_ZZZ_length() + MODBYTES_XXX + MODBYTES_XXX));
 
     return ret;
 }

--- a/libecdaa/schnorr/schnorr_ZZZ.c
+++ b/libecdaa/schnorr/schnorr_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -59,6 +59,7 @@ void schnorr_keygen_ZZZ(ECP_ZZZ *public_out,
 
 int schnorr_sign_ZZZ(BIG_XXX *c_out,
                      BIG_XXX *s_out,
+                     BIG_XXX *n_out,
                      ECP_ZZZ *K_out,
                      const uint8_t *msg_in,
                      uint32_t msg_len,
@@ -75,10 +76,12 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
     int commit_ret = commit(basepoint, private_key, basename, basename_len, &k, &P2, K_out, &L, &R, get_random);
     if (0 != commit_ret)
         return -1;
-    
-    // 2) (Sign 1) Compute hash
+
+    // 2) (Sign 1) Compute first hash
+    //      (modular-reduce c', too).
+    BIG_XXX c_prime;
     if (basename_len != 0) {
-        // Compute c = Hash( R | basepoint | public_key | L | P2 | K_out | basename | msg_in )
+        // Compute c' = Hash( R | basepoint | public_key | L | P2 | K_out | basename | msg_in )
         uint8_t hash_input_begin[SIX_ECP_LENGTH];
         assert(6*ECP_ZZZ_LENGTH == sizeof(hash_input_begin));
         ecp_ZZZ_serialize(hash_input_begin, &R);
@@ -87,20 +90,31 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
         ecp_ZZZ_serialize(hash_input_begin+3*ECP_ZZZ_LENGTH, &L);
         ecp_ZZZ_serialize(hash_input_begin+4*ECP_ZZZ_LENGTH, &P2);
         ecp_ZZZ_serialize(hash_input_begin+5*ECP_ZZZ_LENGTH, K_out);
-        big_XXX_from_three_message_hash(c_out, hash_input_begin, sizeof(hash_input_begin), basename, basename_len, msg_in, msg_len);
+        big_XXX_from_three_message_hash(&c_prime, hash_input_begin, sizeof(hash_input_begin), basename, basename_len, msg_in, msg_len);
     } else {
-        // Compute c = Hash( R | basepoint | public_key | msg_in )
+        // Compute c' = Hash( R | basepoint | public_key | msg_in )
         uint8_t hash_input_begin[THREE_ECP_LENGTH];
         assert(3*ECP_ZZZ_LENGTH == sizeof(hash_input_begin));
         ecp_ZZZ_serialize(hash_input_begin, &R);
         ecp_ZZZ_serialize(hash_input_begin+ECP_ZZZ_LENGTH, basepoint);
         ecp_ZZZ_serialize(hash_input_begin+2*ECP_ZZZ_LENGTH, public_key);
-        big_XXX_from_two_message_hash(c_out, hash_input_begin, sizeof(hash_input_begin), msg_in, msg_len);
+        big_XXX_from_two_message_hash(&c_prime, hash_input_begin, sizeof(hash_input_begin), msg_in, msg_len);
     }
-
-    // 3) (Sign 2) Compute s = k + c * private_key
     BIG_XXX curve_order;
     BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
+    BIG_XXX_mod(c_prime, curve_order);
+
+    // 3) (Sign 2) Compute n <- Z_n
+    ecp_ZZZ_random_mod_order(n_out, get_random);
+
+    // 4) (Sign 3) Compute final hash
+    //      c_out = Hash(n | c')
+    uint8_t final_hash_input_begin[2*MODBYTES_XXX];
+    BIG_XXX_toBytes((char*)final_hash_input_begin, *n_out);
+    BIG_XXX_toBytes((char*)(final_hash_input_begin+MODBYTES_XXX), c_prime);
+    big_XXX_from_hash(c_out, final_hash_input_begin, sizeof(final_hash_input_begin));
+
+    // 5) (Sign 4) Compute s = k + c_out * private_key
     big_XXX_mod_mul_and_add(s_out, k, *c_out, private_key, curve_order);    // normalizes and mod-reduces s_out and c_out
 
     // Clear intermediate, sensitive memory.
@@ -111,6 +125,7 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
 
 int schnorr_verify_ZZZ(BIG_XXX c,
                        BIG_XXX s,
+                       BIG_XXX n,
                        ECP_ZZZ *K,
                        const uint8_t *msg_in,
                        uint32_t msg_len,
@@ -140,9 +155,9 @@ int schnorr_verify_ZZZ(BIG_XXX c,
     // Nb. No need to call ECP_ZZZ_affine here,
     // as R gets passed to ECP_ZZZ_toOctet in a minute (which implicitly converts to affine)
 
-    // 5) Compute hash
-    //      (modular-reduce c', too).
-    BIG_XXX c_prime;
+    // 5) Compute inner hash
+    //      (modular-reduce c'', too)
+    BIG_XXX c_dbl_prime;
     if (0 != basename_len) {
         // 1,2,3,4 part ii) If checking a basename signature:
         ECP_ZZZ P2;
@@ -164,7 +179,7 @@ int schnorr_verify_ZZZ(BIG_XXX c,
         // 4) Compute difference of L and c*K, and save to L (L = s*P2 - c*K)
         ECP_ZZZ_sub(&L, &K_c);
 
-        // c' = Hash( R | basepoint | public_key | L | P2 | K | basename | msg_in )
+        // c'' = Hash( R | basepoint | public_key | L | P2 | K | basename | msg_in )
         uint8_t hash_input_begin[SIX_ECP_LENGTH];
         assert(6*ECP_ZZZ_LENGTH == sizeof(hash_input_begin));
         ecp_ZZZ_serialize(hash_input_begin, &R);
@@ -173,22 +188,28 @@ int schnorr_verify_ZZZ(BIG_XXX c,
         ecp_ZZZ_serialize(hash_input_begin+3*ECP_ZZZ_LENGTH, &L);
         ecp_ZZZ_serialize(hash_input_begin+4*ECP_ZZZ_LENGTH, &P2);
         ecp_ZZZ_serialize(hash_input_begin+5*ECP_ZZZ_LENGTH, K);
-        big_XXX_from_three_message_hash(&c_prime, hash_input_begin, sizeof(hash_input_begin), basename, basename_len, msg_in, msg_len);
-        BIG_XXX curve_order;
-        BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
-        BIG_XXX_mod(c_prime, curve_order);
+        big_XXX_from_three_message_hash(&c_dbl_prime, hash_input_begin, sizeof(hash_input_begin), basename, basename_len, msg_in, msg_len);
     } else {
-        // c' = Hash( R | basepoint | public_key | msg_in )
+        // c'' = Hash( R | basepoint | public_key | msg_in )
         uint8_t hash_input_begin[THREE_ECP_LENGTH];
         assert(3*ECP_ZZZ_LENGTH == sizeof(hash_input_begin));
         ecp_ZZZ_serialize(hash_input_begin, &R);
         ecp_ZZZ_serialize(hash_input_begin+ECP_ZZZ_LENGTH, basepoint);
         ecp_ZZZ_serialize(hash_input_begin+2*ECP_ZZZ_LENGTH, public_key);
-        big_XXX_from_two_message_hash(&c_prime, hash_input_begin, sizeof(hash_input_begin), msg_in, msg_len);
-        BIG_XXX curve_order;
-        BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
-        BIG_XXX_mod(c_prime, curve_order);
+        big_XXX_from_two_message_hash(&c_dbl_prime, hash_input_begin, sizeof(hash_input_begin), msg_in, msg_len);
     }
+    BIG_XXX curve_order;
+    BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
+    BIG_XXX_mod(c_dbl_prime, curve_order);
+
+    // 6) Compute final hash c' = Hash(n | c'')
+    //      (modular-reduce c', too).
+    BIG_XXX c_prime;
+    uint8_t final_hash_input_begin[2*MODBYTES_XXX];
+    BIG_XXX_toBytes((char*)final_hash_input_begin, n);
+    BIG_XXX_toBytes((char*)(final_hash_input_begin+MODBYTES_XXX), c_dbl_prime);
+    big_XXX_from_hash(&c_prime, final_hash_input_begin, sizeof(final_hash_input_begin));
+    BIG_XXX_mod(c_prime, curve_order);
 
     // 6) Compare c' and c
     if (0 != BIG_XXX_comp(c_prime, c)) {

--- a/libecdaa/schnorr/schnorr_ZZZ.h
+++ b/libecdaa/schnorr/schnorr_ZZZ.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,11 +45,13 @@ void schnorr_keygen_ZZZ(ECP_ZZZ *public_out,
 /*
  * Perform Schnorr signature of msg_in, allowing for a non-standard basepoint and basename.
  *
+ * n_out = RAND(Z_p)
  * if basename:
- *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | RAND(Z_p)*P2 | P2 | [private_key]P2 | basename | msg_in )
+ *  c = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | RAND(Z_p)*P2 | P2 | [private_key]P2 | basename | msg_in )
  *      where P2 = the curve point hashed from basename (cf. `ecp_ZZZ_fromhash`)
  * else:
- *  c_out = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
+ *  c = Hash ( RAND(Z_p)*basepoint | basepoint | public_key | msg_in )
+ * c_out = Hash ( n_out | c )
  * s_out = RAND(Z_p) + c_out * private_key
  *
  * public_key = private_key * basepoint
@@ -62,6 +64,7 @@ void schnorr_keygen_ZZZ(ECP_ZZZ *public_out,
  */
 int schnorr_sign_ZZZ(BIG_XXX *c_out,
                      BIG_XXX *s_out,
+                     BIG_XXX *n_out,
                      ECP_ZZZ *K_out,
                      const uint8_t *msg_in,
                      uint32_t msg_len,
@@ -73,9 +76,9 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
                      ecdaa_rand_func get_random);
 
 /*
- * Verify that (c, s) is a valid Schnorr signature of msg_in, allowing for a non-standard basepoint.
+ * Verify that (c, s, n) is a valid Schnorr signature of msg_in, allowing for a non-standard basepoint.
  *
- * Check c = Hash( s*basepoint - c*public_key | basepoint | public_key | msg_in )
+ * Check c = Hash(n | Hash( s*basepoint - c*public_key | basepoint | public_key | msg_in ) )
  *
  * c and s must be reduced modulo group order (and thus normalized, too), first
  *
@@ -87,6 +90,7 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
  */
 int schnorr_verify_ZZZ(BIG_XXX c,
                        BIG_XXX s,
+                       BIG_XXX n,
                        ECP_ZZZ *K,
                        const uint8_t *msg_in,
                        uint32_t msg_len,

--- a/test/schnorr_ZZZ-tests.c
+++ b/test/schnorr_ZZZ-tests.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -96,16 +96,18 @@ void schnorr_sign_sane()
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
 
     TEST_ASSERT(0 == BIG_XXX_iszilch(c));
     TEST_ASSERT(0 == BIG_XXX_iszilch(s));
+    TEST_ASSERT(0 == BIG_XXX_iszilch(n));
     TEST_ASSERT(0 == BIG_XXX_isunity(c));
     TEST_ASSERT(0 == BIG_XXX_isunity(s));
+    TEST_ASSERT(0 == BIG_XXX_isunity(n));
 
     printf("\tsuccess\n");
 }
@@ -123,13 +125,13 @@ void schnorr_verify_wrong_key()
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
 
-    TEST_ASSERT(-1 == schnorr_verify_ZZZ(c, s, NULL, msg, msg_len, &basepoint, &public_wrong, NULL, 0));
+    TEST_ASSERT(-1 == schnorr_verify_ZZZ(c, s, n, NULL, msg, msg_len, &basepoint, &public_wrong, NULL, 0));
 
     printf("\tsuccess\n");
 }
@@ -148,13 +150,13 @@ void schnorr_verify_wrong_msg()
     uint8_t *msg_wrong = (uint8_t*) "Wrong message";
     uint32_t msg_len_wrong = strlen((char*)msg_wrong);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
 
-    TEST_ASSERT(-1 == schnorr_verify_ZZZ(c, s, NULL, msg_wrong, msg_len_wrong, &basepoint, &public, NULL, 0));
+    TEST_ASSERT(-1 == schnorr_verify_ZZZ(c, s, n, NULL, msg_wrong, msg_len_wrong, &basepoint, &public, NULL, 0));
 
     printf("\tsuccess\n");
 }
@@ -171,11 +173,11 @@ void schnorr_verify_bad_sig()
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
 
-    BIG_XXX c={314,0}, s={2718,0};   // Just set these to random values
+    BIG_XXX c={314,0}, s={2718,0}, n={57721,0};   // Just set these to random values
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(-1 == schnorr_verify_ZZZ(c, s, NULL, msg, msg_len, &basepoint, &public, NULL, 0));
+    TEST_ASSERT(-1 == schnorr_verify_ZZZ(c, s, n, NULL, msg, msg_len, &basepoint, &public, NULL, 0));
 
     printf("\tsuccess\n");
 }
@@ -192,13 +194,13 @@ void schnorr_sign_integration()
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
 
-    TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, NULL, msg, msg_len, &basepoint, &public, NULL, 0));
+    TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, n, NULL, msg, msg_len, &basepoint, &public, NULL, 0));
 
     printf("\tsuccess\n");
 }
@@ -210,7 +212,7 @@ void schnorr_sign_integration_other_basepoint()
     uint8_t *msg = (uint8_t*) "Test message";
     uint32_t msg_len = strlen((char*)msg);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
@@ -224,9 +226,9 @@ void schnorr_sign_integration_other_basepoint()
     ECP_ZZZ_copy(&public, &basepoint);
     ECP_ZZZ_mul(&public, private);
 
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, NULL, msg, msg_len, &basepoint, &public, private, NULL, 0, test_randomness));
 
-    TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, NULL, msg, msg_len, &basepoint, &public, NULL, 0));
+    TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, n, NULL, msg, msg_len, &basepoint, &public, NULL, 0));
 
     printf("\tsuccess\n");
 }
@@ -246,14 +248,14 @@ static void schnorr_basename()
     uint8_t *basename = (uint8_t*) "BASENAME";
     uint32_t basename_len = strlen((char*)basename);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
     ECP_ZZZ K;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &K, msg, msg_len, &basepoint, &public, private, basename, basename_len, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, &K, msg, msg_len, &basepoint, &public, private, basename, basename_len, test_randomness));
 
-    TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, &K, msg, msg_len, &basepoint, &public, basename, basename_len));
+    TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, n, &K, msg, msg_len, &basepoint, &public, basename, basename_len));
 
     printf("\tsuccess\n");
 }
@@ -275,14 +277,14 @@ static void schnorr_wrong_basename_fails()
     uint8_t *wrong_basename = (uint8_t*) "WRONGBASENAME";
     uint32_t wrong_basename_len = strlen((char*)wrong_basename);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
     ECP_ZZZ K;
 
     ECP_ZZZ basepoint;
     ecp_ZZZ_set_to_generator(&basepoint);
-    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &K, msg, msg_len, &basepoint, &public, private, basename, basename_len, test_randomness));
+    TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, &K, msg, msg_len, &basepoint, &public, private, basename, basename_len, test_randomness));
 
-    TEST_ASSERT(0 != schnorr_verify_ZZZ(c, s, &K, msg, msg_len, &basepoint, &public, wrong_basename, wrong_basename_len));
+    TEST_ASSERT(0 != schnorr_verify_ZZZ(c, s, n, &K, msg, msg_len, &basepoint, &public, wrong_basename, wrong_basename_len));
 
     printf("\tsuccess\n");
 }

--- a/test/tpm/CMakeLists.txt
+++ b/test/tpm/CMakeLists.txt
@@ -14,6 +14,12 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
+option(TEST_USE_TCP_TPM "Use the socket-based TCTI in the tests" OFF)
+
+if(TEST_USE_TCP_TPM)
+        add_definitions(-DUSE_TCP_TPM)
+endif()
+
 expand_template(${CMAKE_CURRENT_SOURCE_DIR}/tpm_ZZZ-test-utils.h ECDAA_TPM_UTILS_LIST TRUE)
 
 macro(add_tpm_test_case case_file)

--- a/test/tpm/schnorr_TPM_ZZZ-tests.c
+++ b/test/tpm/schnorr_TPM_ZZZ-tests.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,9 +53,10 @@ void full_test()
     const uint8_t *msg = (uint8_t*)"msg";
     const uint32_t msg_len = 3;
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
     ret = schnorr_sign_TPM_ZZZ(&c,
                                &s,
+                               &n,
                                NULL,
                                msg,
                                msg_len,
@@ -69,7 +70,7 @@ void full_test()
         TEST_ASSERT(0==1);
     }
 
-    ret = schnorr_verify_FP256BN(c, s, NULL, msg, msg_len, &G1, &ctx.public_key, NULL, 0);
+    ret = schnorr_verify_FP256BN(c, s, n, NULL, msg, msg_len, &G1, &ctx.public_key, NULL, 0);
     if (0 != ret) {
         printf("Error in schnorr_verify_TPM_ZZZ, ret=%d, tpm_rc=0x%x\n", ret, ctx.tpm_ctx.last_return_code);
         TEST_ASSERT(0==1);
@@ -98,11 +99,12 @@ static void schnorr_TPM_basename()
     uint8_t *basename = (uint8_t*) "BASENAME";
     uint32_t basename_len = strlen((char*)basename);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
     ECP_FP256BN K;
 
     ret = schnorr_sign_TPM_ZZZ(&c,
                                &s,
+                               &n,
                                &K,
                                msg,
                                msg_len,
@@ -116,7 +118,7 @@ static void schnorr_TPM_basename()
         TEST_ASSERT(0==1);
     }
 
-    TEST_ASSERT(0 == schnorr_verify_FP256BN(c, s, &K, msg, msg_len, &G1, &ctx.public_key, basename, basename_len));
+    TEST_ASSERT(0 == schnorr_verify_FP256BN(c, s, n, &K, msg, msg_len, &G1, &ctx.public_key, basename, basename_len));
 
     tpm_cleanup(&ctx);
 
@@ -143,11 +145,12 @@ static void schnorr_TPM_wrong_basename_fails()
     uint8_t *wrong_basename = (uint8_t*) "WRONGBASENAME";
     uint32_t wrong_basename_len = strlen((char*)wrong_basename);
 
-    BIG_XXX c, s;
+    BIG_XXX c, s, n;
     ECP_FP256BN K;
 
     ret = schnorr_sign_TPM_ZZZ(&c,
                                &s,
+                               &n,
                                &K,
                                msg,
                                msg_len,
@@ -161,7 +164,7 @@ static void schnorr_TPM_wrong_basename_fails()
         TEST_ASSERT(0==1);
     }
 
-    TEST_ASSERT(0 != schnorr_verify_FP256BN(c, s, &K, msg, msg_len, &G1, &ctx.public_key, wrong_basename, wrong_basename_len));
+    TEST_ASSERT(0 != schnorr_verify_FP256BN(c, s, n, &K, msg, msg_len, &G1, &ctx.public_key, wrong_basename, wrong_basename_len));
 
     tpm_cleanup(&ctx);
 

--- a/test/tpm/tpm_ZZZ-test.c
+++ b/test/tpm/tpm_ZZZ-test.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,137 +29,15 @@
 #include <string.h>
 #include <stdio.h>
 
-static void null_point_same_as_generator();
-static void zero_hash_returns_commitment();
-static void commit_with_s2();
-static void one_hash_returns_commitment_plus_priv_key();
+static void signature_math_checks();
 
 int main()
 {
-    null_point_same_as_generator();
-    zero_hash_returns_commitment();
-    commit_with_s2();
-    one_hash_returns_commitment_plus_priv_key();
+    signature_math_checks();
 }
 
-void null_point_same_as_generator()
+void signature_math_checks()
 {
-    int ret = 0;
-
-    printf("Starting tpm-test::null_point_same_as_generator...\n");
-
-    struct tpm_test_context ctx;
-    TEST_ASSERT(0 == tpm_initialize(&ctx));
-
-    // Commit
-    ECP_ZZZ K, L, E;
-    ECP_ZZZ G1;
-    ecp_ZZZ_set_to_generator(&G1);
-    ret = tpm_commit_ZZZ(&ctx.tpm_ctx, NULL, NULL, 0, &K, &L, &E);
-    if (0 != ret) {
-        printf("Error: Tss2_Sys_Commit failed: 0x%x, ret=%d\n", ctx.tpm_ctx.last_return_code, ret);
-        TEST_ASSERT(0 == ret);
-    }
-    printf("Called TPM2_Commit with empty buffers, now count=%d, and \nE:{", ctx.tpm_ctx.commit_counter);
-    uint8_t e_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(e_buf, &E);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", e_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    // Nb. digest == 0
-    TPM2B_DIGEST digest = {.size=32, .buffer={0}};
-
-    // Sign
-    TPMT_SIGNATURE signature;
-    ret = tpm_sign(&ctx.tpm_ctx, &digest, &signature);
-    if (0 != ret) {
-        printf("Error: Tss2_Sign failed: 0x%x\n", ctx.tpm_ctx.last_return_code);
-        TEST_ASSERT(0 == ret);
-    }
-    printf("Called TPM2_Sign with a zero hash, and \ns:{");
-
-    BIG_XXX s;
-    BIG_XXX_fromBytes(s, (char*)signature.signature.ecdaa.signatureS.buffer);
-
-    uint8_t s_buf[MODBYTES_XXX];
-    BIG_XXX_toBytes((char*)s_buf, s);
-    for (int i = 0; i < MODBYTES_XXX; i++) {
-        printf("%#X, ", s_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    ECP_ZZZ_mul(&G1, s);
-    printf("[s]G1={");
-    uint8_t g1_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(g1_buf, &G1);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", g1_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    TEST_ASSERT(ECP_ZZZ_equals(&G1, &E));
-
-    tpm_cleanup(&ctx);
-
-    printf("\tsuccess\n");
-}
-
-void commit_with_s2()
-{
-    int ret = 0;
-
-    printf("Starting tpm-test::commit_with_s2...\n");
-
-    struct tpm_test_context ctx;
-    TEST_ASSERT(0 == tpm_initialize(&ctx));
-
-    ECP_ZZZ G1;
-    ecp_ZZZ_set_to_generator(&G1);
-
-    // Commit
-    ECP_ZZZ K, L, E;
-    uint8_t *message = (uint8_t*)"test message";
-    uint32_t message_length = strlen((char*)message);
-    ret = tpm_commit_ZZZ(&ctx.tpm_ctx, &G1, message, message_length, &K, &L, &E);
-    if (0 != ret) {
-        printf("Error: Tss2_Sys_Commit failed: 0x%x, ret=%d\n", ctx.tpm_ctx.last_return_code, ret);
-        TEST_ASSERT(0 == ret);
-    }
-    printf("Called TPM2_Commit with non-empty s2, now count=%d, \nK:{", ctx.tpm_ctx.commit_counter);
-    uint8_t k_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(k_buf, &K);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", k_buf[i]);
-    }
-    printf("}\nL:");
-    uint8_t l_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(l_buf, &L);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", l_buf[i]);
-    }
-    printf("}\nE:");
-    uint8_t e_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(e_buf, &E);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", e_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    tpm_cleanup(&ctx);
-
-    printf("\tsuccess\n");
-}
-
-void zero_hash_returns_commitment()
-{
-    printf("Starting tpm-test::zero_hash_returns_commitment...\n");
-
     int ret = 0;
 
     struct tpm_test_context ctx;
@@ -169,9 +47,6 @@ void zero_hash_returns_commitment()
     ECP_ZZZ K, L, E;
     ECP_ZZZ G1;
     ecp_ZZZ_set_to_generator(&G1);
-    BIG_XXX exp;
-    ecp_ZZZ_random_mod_order(&exp, test_randomness);
-    ECP_ZZZ_mul(&G1, exp);
     ret = tpm_commit_ZZZ(&ctx.tpm_ctx, &G1, NULL, 0, &K, &L, &E);
     if (0 != ret) {
         printf("Error: Tss2_Sys_Commit failed: 0x%x, ret=%d\n", ctx.tpm_ctx.last_return_code, ret);
@@ -196,80 +71,10 @@ void zero_hash_returns_commitment()
         printf("Error: Tss2_Sign failed: 0x%x\n", ctx.tpm_ctx.last_return_code);
         TEST_ASSERT(0 == ret);
     }
-    printf("Called TPM2_Sign with a zero hash, and \ns:{");
-
     BIG_XXX s;
     BIG_XXX_fromBytes(s, (char*)signature.signature.ecdaa.signatureS.buffer);
 
-    uint8_t s_buf[MODBYTES_XXX];
-    BIG_XXX_toBytes((char*)s_buf, s);
-    for (int i = 0; i < MODBYTES_XXX; i++) {
-        printf("%#X, ", s_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    ECP_ZZZ_mul(&G1, s);
-    printf("[s]G1={");
-    uint8_t g1_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(g1_buf, &G1);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", g1_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    TEST_ASSERT(ECP_ZZZ_equals(&G1, &E));
-
-    tpm_cleanup(&ctx);
-
-    printf("\tsuccess\n");
-}
-
-void one_hash_returns_commitment_plus_priv_key()
-{
-    int ret = 0;
-
-    struct tpm_test_context ctx;
-    TEST_ASSERT(0 == tpm_initialize(&ctx));
-
-    // Commit
-    ECP_ZZZ K, L, E;
-    ECP_ZZZ G1;
-    ecp_ZZZ_set_to_generator(&G1);
-    ret = tpm_commit_ZZZ(&ctx.tpm_ctx, NULL, NULL, 0, &K, &L, &E);
-    if (0 != ret) {
-        printf("Error: Tss2_Sys_Commit failed: 0x%x, ret=%d\n", ctx.tpm_ctx.last_return_code, ret);
-        TEST_ASSERT(0 == ret);
-    }
-    printf("Called TPM2_Commit with empty buffers, now count=%d, and \nE:{", ctx.tpm_ctx.commit_counter);
-    uint8_t e_buf[ECP_ZZZ_LENGTH];
-    ecp_ZZZ_serialize(e_buf, &E);
-    for (int i = 0; i < ECP_ZZZ_LENGTH; i++) {
-        printf("%#X, ", e_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
-
-    // Nb. digest == 1
-    BIG_XXX one;
-    BIG_XXX_one(one);
-    TPM2B_DIGEST digest = {.size=32, .buffer={0}};
-    BIG_XXX_toBytes((char*)digest.buffer, one);
-
-    // Sign
-    TPMT_SIGNATURE signature;
-    ret = tpm_sign(&ctx.tpm_ctx, &digest, &signature);
-    if (0 != ret) {
-        printf("Error: Tss2_Sign failed: 0x%x\n", ctx.tpm_ctx.last_return_code);
-        TEST_ASSERT(0 == ret);
-    }
-
-    BIG_XXX s;
-    BIG_XXX_fromBytes(s, (char*)signature.signature.ecdaa.signatureS.buffer);
-    BIG_XXX c;
-    BIG_XXX_fromBytes(c, (char*)signature.signature.ecdaa.signatureR.buffer);
-
+    // Check that s is a valid finite-field element (just in case).
     BIG_XXX curve_order;
     BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
     if (BIG_XXX_comp(s, curve_order) > 0) {
@@ -277,24 +82,18 @@ void one_hash_returns_commitment_plus_priv_key()
         TEST_ASSERT(0 == 1);
     }
 
-    printf("Called TPM2_Sign with a one hash, and \nc:{");
-    uint8_t c_buf[MODBYTES_XXX];
-    BIG_XXX_toBytes((char*)c_buf, c);
-    for (int i = 0; i < MODBYTES_XXX; i++) {
-        printf("%#X, ", c_buf[i]);
-    }
-    printf("}\n\ns:{");
-    fflush(stdout);
-    uint8_t s_buf[MODBYTES_XXX];
-    BIG_XXX_toBytes((char*)s_buf, s);
-    for (int i = 0; i < MODBYTES_XXX; i++) {
-        printf("%#X, ", s_buf[i]);
-    }
-    printf("}\n\n");
-    fflush(stdout);
+    // Calculate T = Hash(k || c)
+    BIG_XXX T;
+    big_XXX_from_two_message_hash(&T,
+            signature.signature.ecdaa.signatureR.buffer,
+            signature.signature.ecdaa.signatureR.size,
+            digest.buffer,
+            digest.size);
 
+    // Calculate [s]G - [T]pub_key
+    // This should equal E
     ECP_ZZZ_mul(&G1, s);
-    ECP_ZZZ_mul(&ctx.public_key, c);
+    ECP_ZZZ_mul(&ctx.public_key, T);
     ECP_ZZZ_sub(&G1, &ctx.public_key);
     ECP_ZZZ_affine(&G1);
     printf("[s]G1 - c*pub_key={");
@@ -307,7 +106,7 @@ void one_hash_returns_commitment_plus_priv_key()
     fflush(stdout);
 
     if (!ECP_ZZZ_equals(&G1, &E)) {
-        printf("Error: [s]G1 - c*pub_key != E\n");
+        printf("Error: [s]G1 - T*pub_key != E\n");
         TEST_ASSERT(0 == 1);
     }
 


### PR DESCRIPTION
More-recent TPM2.0 specifications include a change to the TPM2_Sign operation that breaks the old implementation of this library. This series updates our implementation to accord with that change.

fixes #112 