### PR TITLE
Use length-checked version of AMCL deserialization when reading output from TPM

### DIFF
--- a/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.c
+++ b/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.c
@@ -100,12 +100,14 @@ int schnorr_sign_TPM_ZZZ(BIG_XXX *c_out,
         return -2;
 
     // 5) (Output) Convert TPMS_SIGNATURE_ECC.signatureS into BIG_XXX
-    assert(MODBYTES_XXX == signature.signature.ecdaa.signatureS.size);
-    BIG_XXX_fromBytes(*s_out, (char*)signature.signature.ecdaa.signatureS.buffer);
+    BIG_XXX_fromBytesLen(*s_out,
+                         (char*)signature.signature.ecdaa.signatureS.buffer,
+                         signature.signature.ecdaa.signatureS.size);
 
     // 6) (Output) Convert TPMS_SIGNATURE_ECC.signatureR into BIG_XXX
-    assert(MODBYTES_XXX == signature.signature.ecdaa.signatureR.size);
-    BIG_XXX_fromBytes(*n_out, (char*)signature.signature.ecdaa.signatureR.buffer);
+    BIG_XXX_fromBytesLen(*n_out,
+                         (char*)signature.signature.ecdaa.signatureR.buffer,
+                         signature.signature.ecdaa.signatureR.size);
 
     // 7) (Output) Compute final hash
     //      c_out = Hash(n | c')

--- a/libecdaa-tpm/tpm/commit_ZZZ.c
+++ b/libecdaa-tpm/tpm/commit_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -163,10 +163,14 @@ int tpm_to_amcl_format(ECP_ZZZ *point_out, TPM2B_ECC_POINT *tpm_in)
         return -2;
 
     BIG_XXX x;
-    BIG_XXX_fromBytes(x, (char*)tpm_in->point.x.buffer);
+    BIG_XXX_fromBytesLen(x,
+                         (char*)tpm_in->point.x.buffer,
+                         tpm_in->point.x.size);
 
     BIG_XXX y;
-    BIG_XXX_fromBytes(y, (char*)tpm_in->point.y.buffer);
+    BIG_XXX_fromBytesLen(y,
+                      (char*)tpm_in->point.y.buffer,
+                      tpm_in->point.y.size);
 
     if (1 == ECP_ZZZ_set(point_out, x, y)) {
         return 0;


### PR DESCRIPTION
When reading the output from TPM_Commit and TPM_Sign, the output values are raw buffers with 2-byte size values preceding them.

Previously, we were assuming constant sizes for these buffers, which most likely should be true in the usual circumstances.

However, we can use the length-checked version of the AMCL deserialization function that we were already using (with no run-time cost) to leverage the size values we already have, just to make sure we don't have any buffer overflows.

This series introduces this length-checking, so that we *should* now be sanitizing all output received from the TPM.