### PR TITLE
Fix transient issues with Schnorr signature primitive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ jobs:
       - cmake --build . -- -j2
       - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
       - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
-      - ctest -VV -E benchmarks -T memcheck
+      - ctest -VV -E benchmarks\|fuzz -T memcheck
       - popd
     after_failure:
       - .travis/show-memcheck-results.sh ${TRAVIS_BUILD_DIR}

--- a/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.c
+++ b/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.c
@@ -64,7 +64,7 @@ int schnorr_sign_TPM_ZZZ(BIG_XXX *c_out,
         ECP_ZZZ P2;
         int32_t hash_ret = ecp_ZZZ_fromhash(&P2, basename, basename_len);
         if (hash_ret < 0)
-            return -1;
+            return -3;
 
         // 2ii) Compute c' = Hash( R | basepoint | public_key | L | P2 | K_out | basename | msg_in )
         uint8_t hash_input_begin[SIX_ECP_LENGTH];

--- a/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.h
+++ b/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.h
@@ -54,7 +54,9 @@ struct ecdaa_prng;
  *
  *  Returns:
  *   0 on success
- *   -1 if basepoint is not valid
+ *   -1 if TPM2_Commit fails
+ *   -2 if TPM2_Sign fails
+ *   -3 if the basename can't be hashed into a G1 point
  */
 int schnorr_sign_TPM_ZZZ(BIG_XXX *c_out,
                          BIG_XXX *s_out,

--- a/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.h
+++ b/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.h
@@ -26,6 +26,8 @@ extern "C" {
 
 struct ecdaa_prng;
 
+#define MAX_TPM_SIGN_ATTEMPTS 10
+
 #include <ecdaa-tpm/tpm_context.h>
 
 #include <amcl/big_XXX.h>
@@ -57,6 +59,7 @@ struct ecdaa_prng;
  *   -1 if TPM2_Commit fails
  *   -2 if TPM2_Sign fails
  *   -3 if the basename can't be hashed into a G1 point
+ *   -4 if TPM2_Sign returns a nonce with fewer than MODBYTES_XXX bytes more than MAX_TPM_SIGN_ATTEMPTS times.
  */
 int schnorr_sign_TPM_ZZZ(BIG_XXX *c_out,
                          BIG_XXX *s_out,

--- a/libecdaa-tpm/tpm/sign.h
+++ b/libecdaa-tpm/tpm/sign.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/libecdaa/schnorr/schnorr_ZZZ.c
+++ b/libecdaa/schnorr/schnorr_ZZZ.c
@@ -134,8 +134,6 @@ int schnorr_verify_ZZZ(BIG_XXX c,
                        const uint8_t *basename,
                        uint32_t basename_len)
 {
-    int ret = 0;
-
     // 1) Check public key for validity
     // NOTE: We assume the public key was obtained from `deserialize`,
     //  which checked its validity.
@@ -165,7 +163,7 @@ int schnorr_verify_ZZZ(BIG_XXX c,
         // 1ii) Find P2 by hashing basename
         int32_t hash_ret = ecp_ZZZ_fromhash(&P2, basename, basename_len);
         if (hash_ret < 0)
-            return -1;
+            return -2;
 
         // 2ii) Multiply P2 by s (L = s*P2)
         ECP_ZZZ_copy(&L, &P2);
@@ -213,10 +211,10 @@ int schnorr_verify_ZZZ(BIG_XXX c,
 
     // 6) Compare c' and c
     if (0 != BIG_XXX_comp(c_prime, c)) {
-        ret = -1;
+        return -1;
     }
 
-    return ret;
+    return 0;
 }
 
 int credential_schnorr_sign_ZZZ(BIG_XXX *c_out,
@@ -278,8 +276,6 @@ int credential_schnorr_verify_ZZZ(BIG_XXX c,
                                   ECP_ZZZ *member_public_key,
                                   ECP_ZZZ *D)
 {
-    int ret = 0;
-
     // 1) Set generator
     ECP_ZZZ generator;
     ecp_ZZZ_set_to_generator(&generator);
@@ -332,10 +328,10 @@ int credential_schnorr_verify_ZZZ(BIG_XXX c,
 
     // 6) Compare c' and c
     if (0 != BIG_XXX_comp(c_prime, c)) {
-        ret = -1;
+        return -1;
     }
 
-    return ret;
+    return 0;
 }
 
 int issuer_schnorr_sign_ZZZ(BIG_XXX *c_out,
@@ -397,8 +393,6 @@ int issuer_schnorr_verify_ZZZ(BIG_XXX c,
                               ECP2_ZZZ *X,
                               ECP2_ZZZ *Y)
 {
-    int ret = 0;
-
     // 1) Set generator_2
     ECP2_ZZZ generator_2;
     ecp2_ZZZ_set_to_generator(&generator_2);
@@ -450,10 +444,10 @@ int issuer_schnorr_verify_ZZZ(BIG_XXX c,
 
     // 6) Compare c' and c
     if (0 != BIG_XXX_comp(c_prime, c)) {
-        ret = -1;
+        return -1;
     }
 
-    return ret;
+    return 0;
 }
 
 int commit(ECP_ZZZ *P1,

--- a/libecdaa/schnorr/schnorr_ZZZ.h
+++ b/libecdaa/schnorr/schnorr_ZZZ.h
@@ -87,6 +87,7 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
  * Returns:
  *  0 on success
  *  -1 if (c, s) is not a valid signature
+ *  -2 if basename_len != 0 and the basename fails to hash to a G1 point
  */
 int schnorr_verify_ZZZ(BIG_XXX c,
                        BIG_XXX s,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,8 @@ set(ECDAA_TEST_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/member_keypair_ZZZ-tests.c
         ${CMAKE_CURRENT_SOURCE_DIR}/schnorr_ZZZ-tests.c
         ${CMAKE_CURRENT_SOURCE_DIR}/signature_ZZZ-tests.c
+
+        ${CMAKE_CURRENT_SOURCE_DIR}/schnorr_ZZZ-fuzz.c
         )
 
 foreach(template_file ${ECDAA_TEST_FILES})

--- a/test/schnorr_ZZZ-fuzz.c
+++ b/test/schnorr_ZZZ-fuzz.c
@@ -1,0 +1,84 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "ecdaa-test-utils.h"
+
+#include "schnorr/schnorr_ZZZ.h"
+
+#include "amcl-extensions/big_XXX.h"
+#include "amcl-extensions/ecp_ZZZ.h"
+#include "amcl-extensions/ecp2_ZZZ.h"
+
+#include <ecdaa/credential_ZZZ.h>
+
+#include <amcl/big_XXX.h>
+#include <amcl/ecp_ZZZ.h>
+
+#include <string.h>
+
+static void schnorr_repeated(int schnorr_repetitions);
+
+int main(int argc, char *argv[])
+{
+    int schnorr_repetitions = 20;
+    if (argc == 2) {
+        schnorr_repetitions = atoi(argv[1]);
+    }
+
+    schnorr_repeated(schnorr_repetitions);
+}
+
+void schnorr_repeated(int schnorr_repetitions)
+{
+    // The basic Schnorr primitive includes randomness in two places:
+    // - in the "commit" stage, and
+    // - for the "n" nonce during the "sign" stage
+
+    printf("Starting schnorr::schnorr_repeated...\n");
+
+    uint8_t *msg = (uint8_t*) "Test message";
+    uint32_t msg_len = strlen((char*)msg);
+
+    uint8_t *basename = (uint8_t*) "BASENAME";
+    uint32_t basename_len = strlen((char*)basename);
+
+    BIG_XXX c, s, n;
+    ECP_ZZZ K;
+
+    ECP_ZZZ basepoint;
+    ecp_ZZZ_set_to_generator(&basepoint);
+    BIG_XXX rand;
+
+    ECP_ZZZ public;
+    BIG_XXX private;
+
+    for (int i=0; i<schnorr_repetitions; ++i) {
+        ecp_ZZZ_random_mod_order(&rand, test_randomness);
+        ECP_ZZZ_mul(&basepoint, rand);
+
+        ecp_ZZZ_random_mod_order(&private, test_randomness);
+        ECP_ZZZ_copy(&public, &basepoint);
+        ECP_ZZZ_mul(&public, private);
+
+        TEST_ASSERT(0 == schnorr_sign_ZZZ(&c, &s, &n, &K, msg, msg_len, &basepoint, &public, private, basename, basename_len, test_randomness));
+
+        TEST_ASSERT(0 == schnorr_verify_ZZZ(c, s, n, &K, msg, msg_len, &basepoint, &public, basename, basename_len));
+    }
+
+    printf("\tsuccess\n");
+}

--- a/test/tpm/CMakeLists.txt
+++ b/test/tpm/CMakeLists.txt
@@ -59,6 +59,8 @@ set(ECDAA_TPM_TEST_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/signature_TPM_ZZZ-tests.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tpm_ZZZ-test.c
         ${CMAKE_CURRENT_SOURCE_DIR}/create_tpm_key-util.c
+
+        ${CMAKE_CURRENT_SOURCE_DIR}/schnorr_TPM_ZZZ-fuzz.c
         )
 
 foreach(template_file ${ECDAA_TPM_TEST_FILES})

--- a/test/tpm/schnorr_TPM_ZZZ-fuzz.c
+++ b/test/tpm/schnorr_TPM_ZZZ-fuzz.c
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *
+ * Copyright 2017 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include "../ecdaa-test-utils.h"
+#include "tpm_ZZZ-test-utils.h"
+
+#include "schnorr-tpm/schnorr_TPM_ZZZ.h"
+#include "schnorr/schnorr_FP256BN.h"
+#include "amcl-extensions/ecp_FP256BN.h"
+
+#include <ecdaa-tpm/tpm_context.h>
+
+#include <string.h>
+
+static void schnorr_TPM_repeated(int schnorr_repetitions);
+
+int main(int argc, char *argv[])
+{
+    int schnorr_repetitions = 5;
+    if (argc == 2) {
+        schnorr_repetitions = atoi(argv[1]);
+    }
+
+    schnorr_TPM_repeated(schnorr_repetitions);
+}
+
+void schnorr_TPM_repeated(int schnorr_repetitions)
+{
+    // The basic Schnorr primitive includes randomness in two places:
+    // - in the "commit" stage, and
+    // - for the "n" nonce during the "sign" stage
+
+    printf("Starting schnorr_TPM::schnorr_TPM_repeated...\n");
+
+    uint8_t *msg = (uint8_t*) "Test message";
+    uint32_t msg_len = strlen((char*)msg);
+
+    uint8_t *basename = (uint8_t*) "BASENAME";
+    uint32_t basename_len = strlen((char*)basename);
+
+    BIG_XXX c, s, n;
+    ECP_ZZZ K;
+
+    ECP_ZZZ basepoint;
+    ecp_ZZZ_set_to_generator(&basepoint);
+    // BIG_XXX rand;
+
+    struct tpm_test_context ctx;
+
+    for (int i=0; i<schnorr_repetitions; ++i) {
+        TEST_ASSERT(0 == tpm_initialize(&ctx));
+
+        // ecp_ZZZ_random_mod_order(&rand, test_randomness);
+        // ECP_ZZZ_mul(&basepoint, rand);
+
+        int ret = schnorr_sign_TPM_ZZZ(&c, &s, &n, &K, msg, msg_len, &basepoint, &ctx.public_key, basename, basename_len, &ctx.tpm_ctx);
+        if (0 != ret) {
+            printf("Error in schnorr_sign_TPM_ZZZ, ret=%d, tpm_rc=0x%x\n", ret, ctx.tpm_ctx.last_return_code);
+            TEST_ASSERT(0==1);
+        }
+
+        ret = schnorr_verify_ZZZ(c, s, n, &K, msg, msg_len, &basepoint, &ctx.public_key, basename, basename_len);
+        if (0 != ret) {
+            printf("Error in schnorr_verify_TPM_ZZZ, ret=%d, tpm_rc=0x%x\n", ret, ctx.tpm_ctx.last_return_code);
+            TEST_ASSERT(0==1);
+        }
+
+        tpm_cleanup(&ctx);
+    }
+
+    printf("\tsuccess\n");
+}
+

--- a/test/tpm/schnorr_TPM_ZZZ-tests.c
+++ b/test/tpm/schnorr_TPM_ZZZ-tests.c
@@ -118,7 +118,11 @@ static void schnorr_TPM_basename()
         TEST_ASSERT(0==1);
     }
 
-    TEST_ASSERT(0 == schnorr_verify_FP256BN(c, s, n, &K, msg, msg_len, &G1, &ctx.public_key, basename, basename_len));
+    ret = schnorr_verify_FP256BN(c, s, n, &K, msg, msg_len, &G1, &ctx.public_key, basename, basename_len);
+    if (0 != ret) {
+        printf("Error in schnorr_verify_TPM_ZZZ, ret=%d, tpm_rc=0x%x\n", ret, ctx.tpm_ctx.last_return_code);
+        TEST_ASSERT(0==1);
+    }
 
     tpm_cleanup(&ctx);
 
@@ -164,7 +168,11 @@ static void schnorr_TPM_wrong_basename_fails()
         TEST_ASSERT(0==1);
     }
 
-    TEST_ASSERT(0 != schnorr_verify_FP256BN(c, s, n, &K, msg, msg_len, &G1, &ctx.public_key, wrong_basename, wrong_basename_len));
+    ret = schnorr_verify_FP256BN(c, s, n, &K, msg, msg_len, &G1, &ctx.public_key, wrong_basename, wrong_basename_len);
+    if (0 == ret) {
+        printf("Error in schnorr_verify_TPM_ZZZ (expected non-zero return), ret=%d, tpm_rc=0x%x\n", ret, ctx.tpm_ctx.last_return_code);
+        TEST_ASSERT(0==1);
+    }
 
     tpm_cleanup(&ctx);
 


### PR DESCRIPTION
The recent changes to the Schnorr signature primitive (underlying the actual DAA signature) that were made to work with recent TPMs exposed some issues with the Schnorr signatures:
- Our implementation was missing a modular-reduction of one of the hash outputs during signature generation, which intermittently caused valid signatures to fail verification (particularly for the 254-bit curves)
- The TPM spec appears to specify that the nonce generated during TPM_Sign can be fed into the final hash as a variable-length encoding. Our implementation, however, was assuming that the nonce is always 32bytes (cf. [this discussion](https://github.com/xaptum/ecdaa/pull/116#issuecomment-437149049))

This is only of concern in the somewhat-rare (~1/256 probability) event that the randomly-generated nonce value doesn't have 32 significant bytes. However, in that event, the TPM trims the leading zeroes from the serialization of the nonce before feeding it into the hash function.

Really, variable-length input to a hash for a signature scheme like this is a bad idea, and considering that the signature specification in the literature treats the nonce as a finite-field number (which, in crypto specifications, are generally serialized to fixed length), the intention with DAA is that this should be a fixed-length serialization.

So, to avoid this issue, this series introduces a retry into the call to TPM_Sign: if that call returns a nonce that's not full-length, it's called again.