### PR TITLE
cmake: Install non-templatized header files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_script:
 script:
   - pushd ${ECDAA_BUILD_DIR}
   - cmake --build . --target install -- -j2
+  - ${TRAVIS_BUILD_DIR}/.travis/build-against-installed.sh ${ECDAA_INSTALL_DIR} ${INSTALL_PREFIX} ${TRAVIS_BUILD_DIR}
   - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
   - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
   - ctest -VV

--- a/.travis/build-against-installed.sh
+++ b/.travis/build-against-installed.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Attempt to build a project that depends on ecdaa,
+# to test that an installation of ecdaa works correctly.
+
+set -e
+
+if [[ $# -ne 3 ]]; then
+        echo "usage: $0 <ecdaa installation directory> <system install directory> <tmp directory>"
+        exit 1
+fi
+
+install_dir="$1"
+sys_install_dir="$2"
+tmp_dir="$3"
+output_file=${tmp_dir}/installation-test.out
+
+function cleanup()
+{
+        rm -f $output_file
+}
+trap cleanup INT KILL EXIT
+
+LIB_DIR="${install_dir}/lib"
+SYS_LIB_DIR="${sys_install_dir}/lib"
+
+INCLUDE_FLAGS="-I${install_dir}/include -I${sys_install_dir}/include"
+LINKER_FLAGS="-L${LIB_DIR} -L${SYS_LIB_DIR}/lib -lecdaa -lecdaa-tpm"
+
+echo "Attempting to build downstream program..."
+cc $INCLUDE_FLAGS -x c - -o $output_file -std=c99 $LINKER_FLAGS <<'EOF'
+#include <stdio.h>
+#include <ecdaa.h>
+#include <ecdaa-tpm.h>
+int main() {
+printf("It worked!\n");
+}
+EOF
+echo "ok"
+
+echo "Attempting to run downstream executable..."
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIB_DIR}:${SYS_LIB_DIR}
+${output_file}
+echo "ok"

--- a/libecdaa-tpm/CMakeLists.txt
+++ b/libecdaa-tpm/CMakeLists.txt
@@ -134,6 +134,11 @@ endif()
 ################################################################################
 # Headers
 ################################################################################
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ecdaa-tpm
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        PATTERN "*_ZZZ.h" EXCLUDE
+)
+
 install(DIRECTORY ${ECDAA_TPM_GENERATED_TOPLEVEL_INCLUDE_DIR}/ecdaa-tpm
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )

--- a/libecdaa/CMakeLists.txt
+++ b/libecdaa/CMakeLists.txt
@@ -133,6 +133,11 @@ endif()
 ################################################################################
 # Headers
 ################################################################################
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ecdaa
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        PATTERN "*_ZZZ.h" EXCLUDE
+)
+
 install(DIRECTORY ${ECDAA_GENERATED_TOPLEVEL_INCLUDE_DIR}/ecdaa
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )


### PR DESCRIPTION
This fixes a reversion from commit 65c45de.

When we removed non-templated header files from being processed by the expander, that also meant they weren't getting copied into the build directory. During building, this was OK because we also added the source directory to the include directories. However, because we install *only* the include directories under the build directory, this meant the non-templated (but part of the public API) header files weren't installed.