### PR TITLE
Update options and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,10 @@ include(DetermineWordSize)
 
 option(BUILD_SHARED_LIBS "Build as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build as a static library" OFF)
-option(BUILD_TOOL "Build with ECDAA tools" ON)
 
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
+option(BUILD_EXAMPLES "Build examples" OFF)
+option(BUILD_TOOL "Build with ECDAA tools" ON)
 
 # If not building as a shared library, force build as a static.  This
 # is to match the CMake default semantics of using

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The following CMake configuration options are supported.
 |                                     | Dev             |            | With full optimizations and warnings treated as errors   |
 |                                     | DevDebug        |            | With debug symbols and warnings treated as errors        |
 | CMAKE_INSTALL_PREFIX                | <string>        | /usr/local | The directory to install the library in.                 |
+| BUILD_BENCHMARKS                    | ON, OFF         | ON         | Build benchmark programs                                 |
 | BUILD_EXAMPLES                      | ON, OFF         | OFF        | Build example programs                                   |
+| BUILD_TOOL                          | ON, OFF         | ON         | Build benchmark programs                                 |
 | BUILD_SHARED_LIBS                   | ON, OFF         | ON         | Build shared libraries.                                  |
 | BUILD_STATIC_LIBS                   | ON, OFF         | OFF        | Build static libraries.                                  |
 | BUILD_TESTING                       | ON, OFF         | ON         | Build the test suite.                                    |


### PR DESCRIPTION
Some of the `BUILD_xxx` options were either not explicitly declared in `CMakeLists.txt` or documented in the README.  This series fixes those inconsistencies.