### PR TITLE
Change AMCL url since the original is not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   global:
     - INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr
     - CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
-    - AMCL_DIR=${TRAVIS_BUILD_DIR}/milagro-crypto-c/install
+    - AMCL_DIR=${TRAVIS_BUILD_DIR}/amcl/install
     - XAPTUM_TPM_DIR=${TRAVIS_BUILD_DIR}/xaptum-tpm/
     - IBM_TPM_DIR=${TRAVIS_BUILD_DIR}/ibm-tpm-simulator
     - ECDAA_CURVES=FP256BN,BN254,BN254CX,BLS383

--- a/.travis/install-amcl.sh
+++ b/.travis/install-amcl.sh
@@ -20,8 +20,8 @@ if [[ $# -ne 2 ]]; then
         exit 1
 fi
 
-repo_url=https://github.com/milagro-crypto/milagro-crypto-c
-tag=4.7.0
+repo_url=https://github.com/xaptum/amcl
+tag=4.7.3
 source_dir="$1"
 curves="$2"
 git clone -b $tag "${repo_url}" "${source_dir}"


### PR DESCRIPTION
Same change as in PR as [#115 in XTT](https://github.com/xaptum/xtt/pull/115) and [#2 in homebrew-xaptum](https://github.com/xaptum/homebrew-xaptum/pull/2) 