### PR TITLE
Improve docs, get tests working in CI, and consolidate file I/O implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ matrix:
           - TYPE=SANITIZE
           - BUILD_TYPE=RelWithSanitize
       - if: branch = coverity_scan
-        name: "Coverage"
+        name: "Coverity Scan"
         env: TYPE=COVERITY_SCAN
         env:
           - secure: "jZ3ilXiiqM2qdkPXkOow0RqHz9eA4zZwZbhDKjBfL2wFEiV8u9u5GSzXjLZ6++oh5UzIyp/UdfLyN7vp1+mm7XSYx9X3TeLCmhmP/PZkys/YzrBgTeIxgLubekI4kOa9YdgPQ+d35Nm0AXngw2WrSaefeeKeaRTn/LFAfI5SYlhBXnnZmsRORuCCWDoSWDwvjIUGzcEqpq0uJ+C5Dps8gSExBUFyEkQ5tyaZvCxfujfwB6yP/wDgJzeQL+gSe47/RFinYqJeSvWBViwrGk78sCAZtbHaPy9HbqLUKSslb6WlPMecVbV+kqcN7i4b/bbr68WGDN2fEMzdlBIYJRkhtYFB3nR3T7mh50HQ8l9ZZmWkKekoU9YDcCuRb4HeA20bNF5U/bVFZSnfQPDOXAKnT+jlzAgH3XNEo2YeaCPNLnHZexrGKu9VedzvmCKFjTAW3oj096TLMgon3yg2Wax3XXV7UE0SiRkS9h0P6K1vW+CVKDll6KN5uaRGe4mOOo8Mlb+6l+iagrYpksk4fi4KhhuRkGLOeixNxVWjupaML7C/ShrOzj5XxMkVVgI8Jh7ucY7HguTQW2s6VurZ58jzaqmFBZwZgQ+m1uT7cKnnBBWsL84NVJ1jedPcf034kkxoGABtHWzRGP5gKf3RJTsS7nAwkNXBctKkoNJQ7bQVitM="
@@ -148,11 +148,10 @@ matrix:
               name: "xaptum/ecdaa"
               description: "A C implementation of elliptic-curve-based Direct Anonymous Attestation signatures"
             notification_email: ecdaa-coverity-reports@xaptum.com
-            build_command_prepend: ".travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX} && .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES} && mkdir -p ${ECDAA_BUILD_DIR} && pushd ${ECDAA_BUILD_DIR} && cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON && popd"
-            build_command:   "pushd ${ECDAA_BUILD_DIR} && cmake --build . && popd"
+            build_command: "cmake --build ${ECDAA_BUILD_DIR}"
             branch_pattern: coverity_scan
 
         before_install:
           - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
         script:
-          - echo "Done"
+          - cat "${TRAVIS_BUILD_DIR}/cov-int/scm_log.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,8 @@ matrix:
           - cmake --build . --target install -- -j2
           - ${TRAVIS_BUILD_DIR}/.travis/run-ibm-tpm2.sh ${IBM_TPM_DIR}
           - ${TRAVIS_BUILD_DIR}/.travis/prepare-tpm2.sh ${IBM_TPM_DIR} ${TPM_KEY_DIR}
-          - ctest -VV -E benchmarks\|fuzz -T memcheck
+          - ctest -VV -E benchmarks\|fuzz\|tool_test -T memcheck
+          - ../test/valgrind-tool-test.sh ${ECDAA_BUILD_DIR}/tool
           - popd
         after_failure:
           - .travis/show-memcheck-results.sh ${TRAVIS_BUILD_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,16 +126,17 @@ matrix:
           - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
         script:
           - .travis/run-scanbuild.sh ${TRAVIS_BUILD_DIR} ${ECDAA_BUILD_DIR}
+      - name: "Sanitizers, gcc"
+        sudo: true
+        env:
+          - TYPE=SANITIZE
+          - BUILD_TYPE=RelWithSanitize
       - name: "Sanitizers, clang"
         sudo: true
         compiler: clang
         env:
           - TYPE=SANITIZE
           - BUILD_TYPE=RelWithSanitize
-        after_success:
-          - pushd ${ECDAA_BUILD_DIR}
-          - ctest -VV -E benchmarks
-          - popd
       - if: branch = coverity_scan
         name: "Coverage"
         env: TYPE=COVERITY_SCAN

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
           - pushd ${ECDAA_BUILD_DIR}
           - cmake --build . --target install -- -j2
           - popd
-          - .travis/run-cppcheck.sh build
+          - .travis/run-cppcheck.sh ${TRAVIS_BUILD_DIR} ${ECDAA_BUILD_DIR}
       - name: "MemCheck"
         env:
           - TYPE=MEMCHECK

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
     - OUT_EXT_REPLACE=OFF
 
 before_script:
-  - .travis/install-amcl.sh ${AMCL_DIR} ${ECDAA_CURVES}
-  - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
+  - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
+  - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
   - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
   - mkdir -p ${ECDAA_BUILD_DIR}
   - pushd ${ECDAA_BUILD_DIR}
@@ -89,8 +89,8 @@ matrix:
             packages:
               - cppcheck
         before_script:
-          - .travis/install-amcl.sh ${AMCL_DIR} ${ECDAA_CURVES}
-          - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
+          - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
+          - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
           - mkdir -p ${ECDAA_BUILD_DIR}
           - pushd ${ECDAA_BUILD_DIR}
           - cmake .. -DCMAKE_BUILD_TYPE=Release -DXAPTUMTPM_LOCAL_DIR=${XAPTUM_TPM_DIR} -DCMAKE_INSTALL_PREFIX=${ECDAA_INSTALL_DIR} -DECDAA_CURVES=FP256BN
@@ -121,8 +121,8 @@ matrix:
         env:
           - TYPE=SCAN_BUILD
         before_script:
-          - .travis/install-amcl.sh ${AMCL_DIR} ${ECDAA_CURVES}
-          - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR}
+          - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
+          - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
         script:
           - .travis/run-scanbuild.sh ${TRAVIS_BUILD_DIR} ${TRAVIS_BUILD_DIR}
       - name: "Sanitizers, clang"
@@ -146,7 +146,7 @@ matrix:
               name: "xaptum/ecdaa"
               description: "A C implementation of elliptic-curve-based Direct Anonymous Attestation signatures"
             notification_email: ecdaa-coverity-reports@xaptum.com
-            build_command_prepend: ".travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} && .travis/install-amcl.sh ${AMCL_DIR} ${ECDAA_CURVES} && mkdir -p ${ECDAA_BUILD_DIR} && pushd ${ECDAA_BUILD_DIR} && cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON && popd"
+            build_command_prepend: ".travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX} && .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES} && mkdir -p ${ECDAA_BUILD_DIR} && pushd ${ECDAA_BUILD_DIR} && cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DBUILD_EXAMPLES=ON && popd"
             build_command:   "pushd ${ECDAA_BUILD_DIR} && cmake --build . && popd"
             branch_pattern: coverity_scan
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
           - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
           - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
         script:
-          - .travis/run-scanbuild.sh ${TRAVIS_BUILD_DIR} ${TRAVIS_BUILD_DIR}
+          - .travis/run-scanbuild.sh ${TRAVIS_BUILD_DIR} ${ECDAA_BUILD_DIR}
       - name: "Sanitizers, clang"
         sudo: true
         compiler: clang

--- a/.travis/install-amcl.sh
+++ b/.travis/install-amcl.sh
@@ -15,20 +15,25 @@
 
 set -e
 
-if [[ $# -ne 2 ]]; then
-        echo "usage: $0 <absolute-path-to-amcl-source-directory> <comma-separated-curve-list>"
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
+if [[ $# -ne 3 ]]; then
+        echo "usage: $0 <source-download-target> <install-target> <comma-separated-curve-list>"
         exit 1
 fi
 
 repo_url=https://github.com/xaptum/amcl
 tag=4.7.3
-source_dir="$1"
-curves="$2"
+source_dir="$(my_expand_path $1)"
+install_dir="$(my_expand_path $2)"
+curves="$3"
+
+rm -rf "${source_dir}"
 git clone -b $tag "${repo_url}" "${source_dir}"
 pushd "${source_dir}"
 mkdir -p build
 pushd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DAMCL_CURVE=${curves} -DAMCL_RSA="" -DAMCL_INCLUDE_SUBDIR=amcl -DBUILD_PYTHON=Off -DBUILD_MPIN=Off -DBUILD_WCC=Off -DBUILD_DOCS=Off  -DBUILD_SHARED_LIBS=On
+cmake .. -DCMAKE_INSTALL_PREFIX=${install_dir} -DAMCL_CURVE=${curves} -DAMCL_RSA="" -DAMCL_INCLUDE_SUBDIR=amcl -DBUILD_PYTHON=Off -DBUILD_MPIN=Off -DBUILD_WCC=Off -DBUILD_DOCS=Off  -DBUILD_SHARED_LIBS=On
 cmake --build .
 cmake --build . --target install
 popd

--- a/.travis/install-ibm-tpm2.sh
+++ b/.travis/install-ibm-tpm2.sh
@@ -15,12 +15,14 @@
 
 set -e
 
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
 if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-tpm-simulator-installation-directory>"
+        echo "usage: $0 <source-download-target>"
         exit 1
 fi
 
-installation_dir="$1"
+installation_dir="$(my_expand_path $1)"
 
 if [[ ! -d "$installation_dir" ]]; then
         git clone https://github.com/xaptum-eng/ibm-tpm2-simulator-mirror "$installation_dir"

--- a/.travis/install-xaptum-tpm.sh
+++ b/.travis/install-xaptum-tpm.sh
@@ -15,17 +15,22 @@
 
 set -e
 
-if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-xaptum-tpm-source-directory>"
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <source-download-target> <install-target>"
         exit 1
 fi
 
-source_dir="$1"
+source_dir="$(my_expand_path $1)"
+install_dir="$(my_expand_path $2)"
+
+rm -rf "${source_dir}"
 git clone https://github.com/xaptum/xaptum-tpm "${source_dir}"
 pushd "${source_dir}"
 mkdir -p build
 pushd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DBUILD_SHARED_LIBS=On -DBUILD_TESTING=On
+cmake .. -DCMAKE_INSTALL_PREFIX=${install_dir} -DBUILD_SHARED_LIBS=On -DBUILD_TESTING=On
 cmake --build .
 cmake --build . --target install
 popd

--- a/.travis/path_expansion.sh
+++ b/.travis/path_expansion.sh
@@ -1,0 +1,10 @@
+# For inclusion, to provide path expansion
+
+function my_expand_path {
+        if [[ "${1:0:1}" == "/" ]]; then
+                echo "$1"
+        else
+                echo "$(pwd)/$1"
+        fi
+}
+

--- a/.travis/prepare-tpm2.sh
+++ b/.travis/prepare-tpm2.sh
@@ -15,12 +15,14 @@
 
 set -e
 
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
 if [[ $# -ne 2 ]]; then
-        echo "usage: $0 <absolute-path-to-tpm-simulator-installation-directory> <absolute-path-to-save-public-key>"
+        echo "usage: $0 <tpm simulator directory> <path to save key info>"
         exit 1
 fi
 
-installation_dir="$1"
-out_dir="$2"
+installation_dir="$(my_expand_path $1)"
+out_dir="$(my_expand_path $2)"
 
 ${installation_dir}/create_daa_key.sh "${out_dir}/pub_key.txt" "${out_dir}/handle.txt"

--- a/.travis/run-cppcheck.sh
+++ b/.travis/run-cppcheck.sh
@@ -17,14 +17,24 @@ set -e
 
 source "${BASH_SOURCE%/*}/path_expansion.sh"
 
-if [[ $# -eq 0 ]]; then
-        generated_sources_dir="`pwd`"
-elif [[ $# -eq 1 ]]; then
-        generated_sources_dir="$(my_expand_path $1)"
-else
-        echo "usage: $0 <path-to-toplevel-directory>"
+if [[ $# -ne 2 ]]; then
+        echo "usage: $0 <toplevel-directory> <build-directory>"
         exit 1
 fi
 
+toplevel_dir="$(my_expand_path $1)"
+generated_sources_dir="$(my_expand_path $2)"
+
 # "error-exitcode" makes bugs cause non-zero return code
-cppcheck -v --std=c99 --error-exitcode=6 --enable=all --suppress=missingIncludeSystem -I ${generated_sources_dir}/include/ -I ${generated_sources_dir} -I ${generated_sources_dir}/src/ -I ${generated_sources_dir}/src/tpm-utils/ -I ${generated_sources_dir}/src/internal/ -I ${generated_sources_dir}/src/amcl-extensions/ ${generated_sources_dir}/src/ ${generated_sources_dir}/test/ ${generated_sources_dir}/examples/ --suppress=purgedConfiguration
+cppcheck -v --std=c99 --error-exitcode=6 --enable=all --suppress=missingIncludeSystem \
+        -I ${toplevel_dir}/libecdaa/include/ -I ${toplevel_dir}/libecdaa-tpm/include/ \
+        -I ${toplevel_dir}/common -I ${toplevel_dir}/libecdaa -I ${toplevel_dir}/libecdaa-tpm \
+        -I ${toplevel_dir}/tool \
+        -I ${toplevel_dir}/test -I ${toplevel_dir}/test/tpm \
+        -I ${generated_sources_dir}/libecdaa/include/ -I ${generated_sources_dir}/libecdaa-tpm/include/ \
+        -I ${generated_sources_dir}/common -I ${generated_sources_dir}/libecdaa -I ${generated_sources_dir}/libecdaa-tpm \
+        -I ${generated_sources_dir}/tool \
+        -I ${generated_sources_dir}/test -I ${generated_sources_dir}/test/tpm \
+        ${generated_sources_dir}/common ${generated_sources_dir}/libecdaa/ ${generated_sources_dir}/libecdaa-tpm/ \
+        ${generated_sources_dir}/tool \
+        ${generated_sources_dir}/test ${generated_sources_dir}/test/tpm

--- a/.travis/run-cppcheck.sh
+++ b/.travis/run-cppcheck.sh
@@ -15,10 +15,12 @@
 
 set -e
 
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
 if [[ $# -eq 0 ]]; then
         generated_sources_dir="`pwd`"
 elif [[ $# -eq 1 ]]; then
-        generated_sources_dir="$1"
+        generated_sources_dir="$(my_expand_path $1)"
 else
         echo "usage: $0 <path-to-toplevel-directory>"
         exit 1

--- a/.travis/run-ibm-tpm2.sh
+++ b/.travis/run-ibm-tpm2.sh
@@ -15,12 +15,14 @@
 
 set -e
 
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
 if [[ $# -ne 1 ]]; then
-        echo "usage: $0 <absolute-path-to-tpm-simulator-installation-directory>"
+        echo "usage: $0 <path-to-tpm-simulator-installation-directory>"
         exit 1
 fi
 
-installation_dir="$1"
+installation_dir="$(my_expand_path $1)"
 
 pkill tpm_server || true
 

--- a/.travis/run-scanbuild.sh
+++ b/.travis/run-scanbuild.sh
@@ -15,14 +15,16 @@
 
 set -e
 
+source "${BASH_SOURCE%/*}/path_expansion.sh"
+
 if [[ $# -ne 2 ]]; then
-        echo "usage: $0 <absolute-path-to-cmakelists-directory> <absolute-path-to-cmake-build-directory>"
+        echo "usage: $0 <path-to-cmakelists-directory> <path-to-cmake-build-directory>"
         exit 1
 fi
 
-cmake_dir="$1"
+cmake_dir="$(my_expand_path $1)"
 
-build_dir="$2"
+build_dir="$(my_expand_path $2)"
 mkdir -p "$build_dir"
 cd "$build_dir"
 scan-build cmake "$cmake_dir" -DCMAKE_BUILD_TYPE=Debug

--- a/.travis/run-scanbuild.sh
+++ b/.travis/run-scanbuild.sh
@@ -28,4 +28,5 @@ build_dir="$(my_expand_path $2)"
 mkdir -p "$build_dir"
 cd "$build_dir"
 scan-build cmake "$cmake_dir" -DCMAKE_BUILD_TYPE=Debug
-scan-build --status-bugs cmake --build . -- -j2 #status-bugs means a bug causes a non-zero return code
+scan-build cmake --build . -- -j2 # First, build as usual, to make sure the build itself is passing
+scan-build --status-bugs cmake --build . -- -j2 # status-bugs means a bug causes a non-zero return code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ list(APPEND CMAKE_MODULE_PATH CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 project(ecdaa
         LANGUAGES C
-        VERSION "0.10.1")
+        VERSION "0.10.3")
 
 include(GNUInstallDirs)
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 
 add_compile_options(-std=c99 -Wall -Wextra -Wno-missing-field-initializers)
 SET(CMAKE_C_FLAGS_DEBUGWITHCOVERAGE "${CMAKE_C_FLAGS_DEBUGWITHCOVERAGE} -O0 -fprofile-arcs -ftest-coverage")
-SET(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
+SET(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined")
 SET(CMAKE_C_FLAGS_DEV "${CMAKE_C_FLAGS_RELEASE} -Werror")
 SET(CMAKE_C_FLAGS_DEVDEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,17 +66,6 @@ SET(CMAKE_C_FLAGS_RELWITHSANITIZE "${CMAKE_C_FLAGS_RELWITHSANITIZE} -O2 -g -fsan
 SET(CMAKE_C_FLAGS_DEV "${CMAKE_C_FLAGS_RELEASE} -Werror")
 SET(CMAKE_C_FLAGS_DEVDEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
-# The following options are automatically passed to the `memcheck` executable:
-# `--error-exitcode=5` A memory error causes a return code of 5, so memory errors will fail the tests.
-# `--leak-check=full` Search for memory leaks after program completion, and give a full report for each individually.
-#   - As we're striving for "malloc-free" code, we expect to have zero memory leaks
-# `-v` Verbose `memcheck` output
-# `--track-origins=yes` Track the origin of uninitialized values (small Valgrind performance hit)
-# `--partial-loads-ok=no` Loads from partially invalid addresses are treated the same as loads from completely invalid addresses
-find_program(MEMORYCHECK_COMMAND NAMES valgrind)
-set(MEMORYCHECK_COMMAND_OPTIONS
-        "--error-exitcode=5 --leak-check=full -v --track-origins=yes --partial-loads-ok=no")
-
 set(TOPLEVEL_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 macro(expand_template template_file srcs_list use_tpm is_tool)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,10 @@
+# The following options are automatically passed to the `memcheck` executable:
+# `--error-exitcode=5` A memory error causes a return code of 5, so memory errors will fail the tests.
+# `--leak-check=full` Search for memory leaks after program completion, and give a full report for each individually.
+#   - As we're striving for "malloc-free" code, we expect to have zero memory leaks
+# `-v` Verbose `memcheck` output
+# `--track-origins=yes` Track the origin of uninitialized values (small Valgrind performance hit)
+# `--partial-loads-ok=no` Loads from partially invalid addresses are treated the same as loads from completely invalid addresses
+
+find_program(MEMORYCHECK_COMMAND NAMES valgrind)
+set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --error-exitcode=5 --leak-check=full -v --track-origins=yes --partial-loads-ok=no")

--- a/README.md
+++ b/README.md
@@ -5,30 +5,45 @@
 [![Coverage Status](https://coveralls.io/repos/github/xaptum/ecdaa/badge.svg?branch=master)](https://coveralls.io/github/xaptum/ecdaa?branch=master)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/13775/badge.svg)](https://scan.coverity.com/projects/xaptum-ecdaa)
 
-A C implementation of elliptic-curve-based Direct Anonymous Attestation signatures.
+A C implementation of elliptic-curve-based [Direct Anonymous Attestation signatures](https://en.wikipedia.org/wiki/Direct_Anonymous_Attestation),
+using the LRSW-DAA scheme.
 
-Created to support the [Xaptum](https://www.xaptum.com) Edge Network
-Fabric, an IoT Network Solution.
-
-The project is self-contained, and provides all DAA functionality for Issuers, Members, and Verifiers.
+The project provides all DAA functionality for Issuers, Members, and Verifiers.
 Pseudonym linking ("basename signatures") is optional, and secret-key revocation lists can be used.
+
+The algorithm used is compatible with Version 1.1 Release Draft of the
+[FIDO ECDAA](https://fidoalliance.org/specs/fido-uaf-v1.1-id-20170202/fido-ecdaa-algorithm-v1.1-id-20170202.html)
+specification.
+Further implementation details can be found in [doc/IMPLEMENTATION.md](doc/IMPLEMENTATION.md).
 
 ## Installation
 
-`ecdaa` is available for the following distributions. It may also be
-built from source.
+See [doc/BUILDING.md](doc/BUILDING.md) for more information on building from source.
+
+Packages are also available for the following distributions.
 
 ### Debian (Jessie or Stretch)
 
 ``` bash
-# Install the Xaptum API repo GPG signing key.
+# Install the Xaptum APT repo GPG signing key.
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys c615bfaa7fe1b4ca
 
 # Add the repository to your APT sources, replacing <dist> with either jessie or stretch.
-echo "deb http://dl.bintray.com/xaptum/deb <dist> main" > /etc/apt/sources.list.d/xaptum.list
+echo "deb http://dl.bintray.com/xaptum/deb <dist> main" | sudo tee /etc/apt/sources.list.d/xaptum.list
 
-# Install the library.
+# Update APT
+sudo apt-get update
+
+# Install the CLI tool and shared library
+sudo apt-get install ecdaa
+
+# For developers, header files and shared libraries can also be installed
 sudo apt-get install libecdaa-dev
+
+# For using a TPM 2.0, install the ecdaa-tpm library (and, optionally, development package)
+sudo apt-get install libecdaa-tpm0
+sudo apt-get install libecdaa-tpm-dev
+
 ```
 
 ### Homebrew (MacOS)
@@ -38,401 +53,72 @@ sudo apt-get install libecdaa-dev
 brew tap xaptum/xaptum
 
 # Install the library.
-brew install xaptum-tpm
+brew install xaptum
 ```
 
-## Installation from Source
+## Usage
 
-### Build Dependencies
+Information on using the library can be found in the [doc/USAGE.md](doc/USAGE.md) document.
 
-* CMake (version 3.0 or higher)
-* Python3 (for file generation during build)
-* A C99-compliant compiler
+The `ecdaa` command-line tool provides a simple, file-based interface for all DAA functionality.
+If building from source, it's available in the `tool` directory.
 
-* [AMCL](https://github.com/milagro-crypto/milagro-crypto-c) (version 4.7)
-  * Built with the support for the necessary curves
-* [xaptum-tpm](https://github.com/xaptum/xaptum-tpm) (version 0.5.0 or higher)
-  * If building ECDAA with TPM support
+A basic Join-Sign-Verify flow is shown below.
 
-### Building
+### Create Group
 
 ```bash
-# Create a subdirectory to hold the build
-mkdir -p build
-cd build
-
-# Configure the build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=ON
-
-# Build the library
-cmake --build .
+# Issuer creates a new keypair
+ecdaa issuer genkeys -p issuer_public.bin -s issuer_private.bin
 ```
 
-### CMake Options
-
-The following CMake configuration options are supported.
-
-| Option                              | Values          | Default    | Description                                              |
-|-------------------------------------|-----------------|------------|----------------------------------------------------------|
-| ECDAA_TPM_SUPPORT                   | ON, OFF         | ON         | Build with support for using a TPM2.0                    |
-| CMAKE_BUILD_TYPE                    | Release         |            | With full optimizations.                                 |
-|                                     | Debug           |            | With debug symbols.                                      |
-|                                     | RelWithDebInfo  |            | With full optimizations and debug symbols.               |
-|                                     | RelWithSanitize |            | With address and undefined-behavior sanitizers.          |
-|                                     | Dev             |            | With full optimizations and warnings treated as errors   |
-|                                     | DevDebug        |            | With debug symbols and warnings treated as errors        |
-| CMAKE_INSTALL_PREFIX                | <string>        | /usr/local | The directory to install the library in.                 |
-| BUILD_BENCHMARKS                    | ON, OFF         | ON         | Build benchmark programs                                 |
-| BUILD_EXAMPLES                      | ON, OFF         | OFF        | Build example programs                                   |
-| BUILD_TOOL                          | ON, OFF         | ON         | Build benchmark programs                                 |
-| BUILD_SHARED_LIBS                   | ON, OFF         | ON         | Build shared libraries.                                  |
-| BUILD_STATIC_LIBS                   | ON, OFF         | OFF        | Build static libraries.                                  |
-| BUILD_TESTING                       | ON, OFF         | ON         | Build the test suite.                                    |
-| STATIC_SUFFIX                       | <string>        | <none>     | Appends a suffix to the static lib name.                 |
-
-### Testing
+`...Issuer distributes issuer_public.bin to any Verifiers...`
 
 ```bash
-cd build
-ctest -V
+# Verifier extracts group public key from Issuer's public key
+ecdaa extractgpk -p issuer_public.bin -g group_public.bin
 ```
 
-Running the integration tests requires `-DBUILD_EXAMPLES=ON`.
+`...Verifier saves group_public.bin...`
 
-#### Testing TPM support
-
-By default, the tests use a device-file-based TCTI.
-For this reason, `sudo` privileges may be required to run them.
-
-The tests can instead be built to use a TCP-socket-based TCTI,
-by using the CMake option `TEST_USE_TCP_TPM=ON`.
-
-The TPM tests require a [TPM 2.0
-simulator](https://sourceforge.net/projects/ibmswtpm2/) running
-locally on TCP port 2321.
-
-An ECDAA signing key must loaded in the TPM. The associated
-public key (in x9.62 format) and TPM handle (as a hex integer) must be
-in `build/test/tpm/pub_key.txt` and `build/test/tpm/handle.txt`.
-Currently, only the `TPM_ECC_BN_P256` curve is supported in the tests.
-
-Convenience scripts in the `.travis` directory can be used to download
-and prepare a TPM2.0 simulator for the tests.
-After building `ecdaa` in the directory `build` with `ECDAA_TPM_SUPPORT=ON`,
-run the following steps:
-``` bash
-.travis/install-ibm-tpm2.sh ./ibm-tpm2-simulator
-.travis/run-ibm-tpm2.sh ./ibm-tpm2-simulator/
-.travis/prepare-tpm2.sh ./ibm-tpm2-simulator ./build/test/tpm
-```
-
-The `ecdaa` tests will now be able to create signatures using the TPM2.0 simulator.
-
-### Installing
+### Join
 
 ```bash
-cd build
-cmake --build . --target install
+# Member creates a keypair
+ecdaa member genkeys -p member_public.bin -s member_private.bin
 ```
 
-# Usage
-
-The only header that has to be included is `ecdaa.h`.  The name of the
-library is `libecdaa`.
-
-The pairing-friendly curves supported by the library are set using the CMake
-variable `ECDAA_CURVES`, a comma-separated list of curve names.
-All curves supported by the `milagro-crypto-c` pairing-based-crypto library are supported.
-If no `ECDAA_CURVES` is set, the default is to build `FP256BN`.
-
-## Using a TPM
-
-This implementation has been tested against the following TCG TPM2.0 specifications:
-- Specification v1.38
-- Specification v1.16 with Errata v1.5
-
-Signatures can be created with the help of a Trusted Platform Module (TPM).
-
-To do so, a signing key must first be created and loaded in the TPM.
-This key must be created with the following properties
-(consult a TPM TSS for explanation of how to create an asymmetric signing key):
-- `sign` attribute must be set
-- `restricted` attribute must NOT be set
-- `userWithAuth` attribute must be set
-  - The authorization must be a (possibly empty) password
-- `scheme = TPM_ALG_ECDAA`
-- `hashAlg = TPM_ALG_SHA256`
-- `curveID = TPM_ECC_BN_P256`
-
-Then, a connection to the TPM is established by, for example, connecting
-to a TPM simulator listening locally on TCP port 2321.
-This creates an `ecdaa_tpm_context` object as follows:
-```
-struct ecdaa_tpm_context tpm_context;
-ecdaa_tpm_context_init_socket(&tpm_context, &public_key, key_handle, localhost, 2321, password, password_length);
-```
-where `public_key` and `key_handle` are the public key (as an elliptic curve point) and TPM handle of
-the TPM signing key, and `password` is the TPM authorization associated with that key.
-
-An ECDAA signature using this TPM-generated secret key is then created using:
-```
-struct ecdaa_signature_FP256BN signature;
-ecdaa_signature_TPM_sign(&signature, msg, msg_length, &credential, &prng, &tpm_context);
-```
-where `credential` is an ECDAA credential obtained earlier and `prng` is an `ecdaa_prng`, both created as usual.
-
-Notice that the signature thus created is not TPM-specific.
-This means that verification of a TPM-generated signature proceeds as usual, using `ecdaa_signature_FP256BN_verify`.
-
-## Cryptographically-secure random numbers
-
-Many of the functions provided by this library (particularly, those used by an Issuer or a Member)
-require a source of cryptographically-secure random numbers.
-
-Such functions take a parameter of type `ecdaa_rand_func`,
-which is a function pointer for a function that will fill a buffer with a given
-number of random bytes.
-The expectation is that this function will use the system's source of randomness
-(e.g. `getrandom` on Linux, `getentropy` on OpenBSD, `arc4random` on Mac OS X,
-`RtlGenRandom` on Windows, or reading from `/dev/urandom` when these others aren't available).
-Note that a `ecdaa_rand_func` will never be called with a request large than 255 bytes
-(so functions like `getrandom` and `getentropy` that have such a limit are OK to use).
-Examples of such usage can be found in the implementation of the example programs,
-in `examples/examples_rand.c`.
-
-The easiest way to satisfy the requirements of the `ecdaa_rand_func` is to use
-the libsodium function `randombytes_buf`, on systems supported by libsodium.
-
-The security of this library depends critically on these random numbers.
-
-## Naming Convention in API
-
-All API functions exist in the `ecdaa` namespace,
-and are focused on a small number of basic `structs` (e.g. `signature`).
-Function names take the form `ecdaa_<struct-name>_<curve-name>_<action>`.
-For example, for generating a credential when using the BN254 curve-type, the function
-to use is `ecdaa_credential_BN254_generate`.
-
-Output parameters are frequently used in the API functions, and come at the beginning
-of the parameter list.
-
-The fundamental structs have (de-)serialization functions,
-and macros and functions giving their serialized length.
-Again, the format of the serialized length macro/function is
-`ecdaa_<struct-name>_<curve-name>_length` (capitalized for the macro).
-
-## Example Programs
-
-The `examples` directory contains example code for using the library,
-where for simplicity communication between the Issuer, Member, and Verifier
-is done using regular files.
-
-The example programs use the FP256BN curve type.
-
-NOTE: If using these example programs on a system where `/dev/urandom` is the only
-option for cryptographically-secure random numbers
-(cf. `/examples/ecdaa_examples_randomness.c`),
-the proper seeding of `/dev/urandom`
-(i.e. the amount of entropy available) is not checked!
-Thus, in such situations, these programs are not safe to use in situations
-where the system random number generator may not be seeded
-(e.g. early in the boot process on some systems).
-The example programs must be explicitly adapted for use in such situations.
-
-### Creating a New DAA Group
-
-When acting as the Issuer, run the `ecdaa_issuer_create_group` command
-to define a new DAA Group.
-This creates a new Issuer public/secret key pair
-(the public/secret key pair is used for adding new members to the group
-during the Join process, and the public key also contains the group public key).
+`...Member sends member_public.bin to Issuer...`
 
 ```bash
-ecdaa_issuer_create_group ipk.bin isk.bin
+# Issuer creates a credential on that public key
+ecdaa issuer issuecredential -p member_public.bin -s issuer_private.bin -c member_credential.bin
 ```
 
-### Join Process
+`...Issuer sends member_credential.bin to Member...`
 
-A Member starts the Join process to be granted membership in the DAA group.
+`...Member saves the member_credential.bin and its member_private.bin...`
 
-The Join process begins with the Member requesting a nonce and issuer public key from the Issuer.
-This process is outside the scope of this project.
+### Sign
 
-Once the Member obtains a nonce and issuer public key from the Issuer, the Member
-first extracts the group public key from the issuer public key.
-If the extraction succeeds (indicating the Issuer is honest), the Member saves the
-group public key.
+`...Member creates a message to be signed in the file message.bin...`
 
 ```bash
-ecdaa_extract_group_public_key ipk.bin gpk.bin
+# Member creates signature over the message
+ecdaa member sign -s member_private.bin -c member_credential.bin -m message.bin -g signature.bin
 ```
 
-Next, the member passes the nonce to the `ecdaa_member_request_join` command to
-generate its public/secret key-pair.
+`...Member sends message.bin and signature.bin to Verifier...`
+
+### Verify 
 
 ```bash
-ecdaa_member_request_join nonce-text pk.bin sk.bin
+# Verifier checks signature
+ecdaa verify -g group_public.bin -m message.bin -s signature.bin
 ```
 
-The Member sends its public key to the Issuer,
-who then passes it (along with its secret key and the nonce
-it originally gave to this Member) to the
-`ecdaa_issuer_respond_to_join_request` command.
-This command checks the validity of the Member's
-public key and generates a DAA credential and credential-signature,
-which the Issuer sends back to the Member.
-
-```bash
-ecdaa_issuer_respond_to_join_request pk.bin isk.bin cred.bin cred_sig.bin nonce-text
-```
-
-The member passes the credential and credential-signature
-(along with its public key, and the group group public key that it extracted earlier)
-to the `ecdaa_member_process_join_response` command.
-This command checks the validity of the Issuer's credential-signature.
-
-```bash
-ecdaa_member_process_join_response pk.bin gpk.bin cred.bin cred_sig.bin
-```
-
-If the credential-signature check succeeds, the Member saves the credential
-along with its secret key (its public key is no longer needed).
-The credential and the member's secret key will be used to create DAA signatures.
-
-### Signing and Verifying
-
-Any party wishing to verfiy DAA signatures for a DAA group
-first obtains the issuer public key for this group, from the pertinent Issuer.
-The verifier then extracts the group public key from this issuer public key,
-as described in the previous section.
-If the extraction succeeds (indicating the Issuer was honest),
-the verifier saves the group public key for all later verifications.
-
-Verifiers also maintain a secret key revocation list, which lists
-DAA secret keys that are known to have been compromised.
-The issuer may be involved in communicating this list to
-all verifiers.
-This process is outside the scope of this project.
-
-A member creates a DAA signature over a message
-using a basename (if pseudonym linking is required by the Verifier)
-by passing its secret key and its credential,
-along with the message to be signed and the basename,
-to the `ecdaa_member_sign` command.
-This command outputs a DAA signature, which the Member
-sends (along with some indication of the DAA group
-it is claiming) to a Verifier.
-
-```bash
-ecdaa_member_sign sk.bin cred.bin sig.bin message.bin basename.bin
-```
-
-The Verifier looks up the group public key (extracted earlier)
-and the basename (if using pseudonym linking)
-for the DAA group claimed by the Signer.
-It passes this group public key and the secret key revocation list for this DAA group,
-along with the message and signature,
-to the `ecdaa_verify` command.
-If the signature is valid, this command returns success.
-
-```bash
-ecdaa_verify message.bin sig.bin gpk.bin sk_revocation_list.bin num-sks-in-sk_revocation_list bsn_revocation_list.bin num_bsns-in-bsn_revocation_list basename.bin
-```
-
-# Algorithm
-
-The signature algorithm is that of
-[Camenisch et al., 2016](https://doi.org/10.1007/978-3-662-49387-8_10),
-with two exceptions:
-- The "fix by Xi et al." discussed in Section 5.2 is NOT used
-when creating TPM-enabled signatures (the current TPM2.0 specification doesn't allow
-such signatures to be created).
-- During signing, a random nonce is included in the message hash, as discussed in
-section 5.2.2 of [Camenisch et al., 2017](https://eprint.iacr.org/2017/639).
-
-# Testing and Analysis
-
-The unit-tests are contained in the `test` directory.
-Test code coverage is measured using `gcov`, and monitored via `coveralls`.
-
-## Valgrind
-
-The Valgrind tool `memcheck` is used for heap memory checking.
-Every build on `travis-ci` runs this test.
-
-To run a `memcheck` test, do the following:
-
-```bash
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo
-cmake --build . -- -j2
-# (benchmarks are excluded because they take too long under the Valgrind instrumentation)
-ctest -VV -E benchmark -T memcheck
-```
-
-## Scan-build
-
-Clang's `scan-build` tool is a general static analyzer, run every build on `travis-ci`.
-
-The `scan-build` tool can be run locally by doing the following:
-
-```bash
-mkdir build
-cd build
-scan-build cmake .. -DCMAKE_BUILD_TYPE=Debug
-scan-build --status-bugs cmake --build . -- -j2 #status-bugs means a bug causes a non-zero return code
-```
-
-Scan-build has a large number of options for specifying the types of bugs to look for,
-so it would be a good idea to study those and tune our usage of this tool.
-
-## cppcheck
-
-The `cppcheck` static analyzer is also available, and is run every build on `travis-ci`.
-To run it do the following:
-
-```bash
-cppcheck --enable=all -v --std=c99 --error-exitcode=6 include/ src/ test/
-```
-
-This tool is generally considered to have a lower false-positive rate than
-many other static analyzers, though with that comes a potential loss of strictness.
-
-## Address and Undefined Behavior Sanitizers
-
-Google produced "sanitizer" tools (code instrumenters that check for errors
-while running, and thus "dynamically") for checking memory use and
-code that may produce undefined behavior.
-These sanitizers are now part of both the Clang and GCC compilers.
-The address sanitizer and undefined behavior sanitizer
-(including the unsigned-int-overflow sanitizer) are run for every build on `travis-ci`.
-
-To run tests using these sanitizers, do the following:
-
-```bash
-mkdir build
-cmake . -DCMAKE_BUILD_TYPE=RelWithSanitize
-cmake --build . -- -j2
-# (benchmarks are excluded because they take too long under the sanitizer instrumentation)
-ctest -VV -E benchmark
-```
-
-## Coverity
-
-Coverity static analysis is run after any push to the `coverity_scan` branch.
-Coverity is a static analyzer provided by Synopsys, and the reports
-for this project can be found by clicking the Coverity link at the top of this README.
-
-# Pairing-based Cryptography Library
-
-For the elliptic curve bilinear pairing primitives, this project
-uses the Milagro Crypto C library.
-The fork currently required by this project is available on github [here](https://github.com/zanebeckwith/milagro-crypto-c).
-The upstream repository can be found [here](https://github.com/milagro-crypto/milagro-crypto-c).
-
-# License
-Copyright 2017-2018 Xaptum, Inc.
+## License
+Copyright 2017-2019 Xaptum, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this work except in compliance with the License. You may obtain a copy of

--- a/common/amcl-extensions/ecp_ZZZ.c
+++ b/common/amcl-extensions/ecp_ZZZ.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ void ecp_ZZZ_set_to_generator(ECP_ZZZ *point)
     BIG_XXX gx, gy;
     BIG_XXX_rcopy(gx, CURVE_Gx_ZZZ);
     BIG_XXX_rcopy(gy, CURVE_Gy_ZZZ);
-    ECP_ZZZ_set(point, gx, gy);
+    (void)ECP_ZZZ_set(point, gx, gy);   // we know this will succeed, b/c the coords are for the generator
 }
 
 void ecp_ZZZ_serialize(uint8_t *buffer_out,

--- a/common/amcl-extensions/ecp_ZZZ.c
+++ b/common/amcl-extensions/ecp_ZZZ.c
@@ -138,7 +138,7 @@ void ecp_ZZZ_random_mod_order(BIG_XXX *big_out,
     // 3) Generate a random BIG bit-by-bit,
     //      then reduce it modulo the group order.
     // Adapted from AMCL big.c.in::BIG_XXX_randomnum() function
-    int i,b,j=0;
+    int i,j=0;
     uint8_t r=0;
     DBIG_XXX d;
     BIG_XXX_dzero(d);
@@ -147,7 +147,7 @@ void ecp_ZZZ_random_mod_order(BIG_XXX *big_out,
     {
         if (j==0) r=get_random_byte(&rand_pool);
         else r>>=1;
-        b=r&1;
+        int b=r&1;
         BIG_XXX_dshl(d,1);
         d[0]+=b;
         j++;

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -1,0 +1,112 @@
+# Building ECDAA from source
+
+## Build Dependencies
+
+* CMake (version 3.0 or higher)
+* Python3 (for file generation during build)
+* A C99-compliant compiler
+
+* [AMCL](https://github.com/xaptum/amcl) (version 4.7)
+  * Built with the support for the necessary curves
+  * This library provides the pairing-based cryptography primitives
+* [xaptum-tpm](https://github.com/xaptum/xaptum-tpm) (version 0.5.0 or higher)
+  * Only required if building ECDAA with TPM support
+  * This library provides a minimal interface to a TPM 2.0 chip
+
+## Pairing-friendly Curves
+
+The pairing-friendly curves used in the library are decided at build time.
+For these instructions, the `ECDAA_CURVES` variable stands for
+a comma-separated list of the curves to use.
+
+The available curves are:
+- 'BN254'
+- 'BN254CX'
+- 'BLS383'
+- 'FP256BN'
+  - Must be included if building with TPM 2.0 support
+
+## Building
+
+```bash
+# Create a subdirectory to hold the build
+mkdir -p build
+cd build
+```
+
+### Building the dependencies from source (optional)
+
+You can build the dependencies from source, rather than using packages.
+
+Note: these steps only build the dependencies as shared libraries.
+To build static libraries, or to use any other specific build options,
+refer to the relevant repositories.
+
+```bash
+# Create a local installation location, and make CMake aware of it
+mkdir -p ./deps
+export CMAKE_PREFIX_PATH=$(pwd)/deps
+
+# Build the AMCL library
+../.travis/install-amcl.sh ./amcl ./deps ${ECDAA_CURVES}
+
+# Build the xaptum-tpm library (if building with TPM support)
+../.travis/install-xaptum-tpm.sh ./xaptum-tpm ./deps
+```
+
+### Building the ECDAA libraries and CLI tool
+
+```bash
+# Configure the build (Don't include the TEST_USE_TCP_TPM if testing against a physical TPM)
+cmake .. -DCMAKE_BUILD_TYPE=Release -DECDAA_CURVES=${ECDAA_CURVES} -DTEST_USE_TCP_TPM=ON
+
+# Build the library
+cmake --build .
+```
+
+## Tests
+
+Note: If a TPM 2.0 or a simulator is not available, the CMake option
+`ECDAA_TPM_SUPPORT` must be set to `OFF` in the build configuration step above
+for all tests to pass.
+
+```bash
+# Run the test suite
+ctest -V
+```
+
+For information on the available tests and benchmarks, see [TESTS.md](TESTS.md).
+
+## Installing
+
+```bash
+cd build
+cmake --build . --target install
+```
+
+Configuration `.pc` files for `pkg-config` are also installed,
+as well as an `ecdaa-config.cmake` file for configuration using CMake.
+
+## CMake Options
+
+The following CMake configuration options are supported.
+
+| Option                              | Values          | Default    | Description                                              |
+|-------------------------------------|-----------------|------------|----------------------------------------------------------|
+| ECDAA_CURVES                        | see above       | FP256BN    | Pairing-friendly curve(s) to use                         |
+| ECDAA_TPM_SUPPORT                   | ON, OFF         | ON         | Build with support for using a TPM2.0                    |
+| CMAKE_BUILD_TYPE                    | Release         |            | With full optimizations.                                 |
+|                                     | Debug           |            | With debug symbols.                                      |
+|                                     | RelWithDebInfo  |            | With full optimizations and debug symbols.               |
+|                                     | RelWithSanitize |            | With address and undefined-behavior sanitizers.          |
+|                                     | Dev             |            | With full optimizations and warnings treated as errors   |
+|                                     | DevDebug        |            | With debug symbols and warnings treated as errors        |
+| CMAKE_INSTALL_PREFIX                | <string>        | /usr/local | The directory to install the library in.                 |
+| BUILD_BENCHMARKS                    | ON, OFF         | ON         | Build benchmark programs                                 |
+| BUILD_EXAMPLES                      | ON, OFF         | OFF        | Build example programs                                   |
+| BUILD_TOOL                          | ON, OFF         | ON         | Build benchmark programs                                 |
+| BUILD_SHARED_LIBS                   | ON, OFF         | ON         | Build shared libraries.                                  |
+| BUILD_STATIC_LIBS                   | ON, OFF         | OFF        | Build static libraries.                                  |
+| BUILD_TESTING                       | ON, OFF         | ON         | Build the test suite.                                    |
+| STATIC_SUFFIX                       | <string>        | <none>     | Appends a suffix to the static lib name.                 |
+| TEST_USE_TCP_TPM                    | ON, OFF         | OFF        | Use a TCP socket TCTI for the TPM tests.                 |

--- a/doc/IMPLEMENTATION.md
+++ b/doc/IMPLEMENTATION.md
@@ -1,0 +1,18 @@
+# Details of the ECDAA Algorithm Used
+
+The signature algorithm is that of
+[Camenisch et al., 2016](https://doi.org/10.1007/978-3-662-49387-8_10),
+with two exceptions:
+- The "fix by Xi et al." discussed in Section 5.2 is NOT used
+when creating TPM-enabled signatures (the current TPM2.0 specification doesn't allow
+such signatures to be created).
+- During signing, a random nonce is included in the message hash, as discussed in
+section 5.2.2 of [Camenisch et al., 2017](https://eprint.iacr.org/2017/639).
+
+This implementation is also compatible with Version 1.1 Release Draft of the
+[FIDO ECDAA](https://fidoalliance.org/specs/fido-uaf-v1.1-id-20170202/fido-ecdaa-algorithm-v1.1-id-20170202.html)
+specification, with the following exception:
+- TPM-based signatures in this implementation do *not* use the `TPM2_Certify` function
+  - Instead, this implementation uses `TPM2_sign` and thus is generic,
+    in the sense that it can be used to sign
+    *any* message, not just a TPM-generated public key.

--- a/doc/TESTS.md
+++ b/doc/TESTS.md
@@ -1,0 +1,145 @@
+# Running the ECDAA test and benchmark suites
+
+## Tests
+
+To run the test suite for a build in the `build` directory:
+```bash
+cd build
+ctest -V
+```
+
+Running the integration tests requires `-DBUILD_EXAMPLES=ON`.
+
+## Benchmarks
+
+If the project is built with the CMake option `-DBUILD_BENCHMARKS=ON`,
+a benchmark suite for each curve is built in the `benchmarksBin` directory.
+
+## Testing TPM Support
+
+If the project is built with the CMake option `-DECDAA_TPM_SUPPORT=ON`,
+some of the tests will require a TPM 2.0 (or a simulator).
+
+By default, the tests use a device-file-based TCTI,
+using device file `/dev/tpm0`.
+For this reason, `sudo` privileges may be required to run them.
+
+The tests can instead be built to use a TCP-socket-based TCTI
+(typically used by a [TPM 2.0 simulator](https://sourceforge.net/projects/ibmswtpm2/))
+by using the CMake option `TEST_USE_TCP_TPM=ON`.
+
+An ECDAA signing key must loaded in the TPM. The associated
+public key (in x9.62 format) and TPM handle (as a hex integer) must be
+in `build/test/tpm/pub_key.txt` and `build/test/tpm/handle.txt`, respectively.
+Currently, only the `TPM_ECC_BN_P256` curve is supported in the tests.
+
+### Convenience Scripts
+
+If using a TPM 2.0 simulator for the tests,
+convenience scripts in the `.travis` directory can be used to download and prepare the simulator:
+```bash
+./.travis/install-ibm-tpm2.sh ./ibm-tpm2-simulator
+./.travis/run-ibm-tpm2.sh ./ibm-tpm2-simulator/
+./.travis/prepare-tpm2.sh ./ibm-tpm2-simulator ./build/test/tpm
+```
+
+Note that the simulator requires OpenSSL libraries and header files to be available.
+
+### Key Creation for a Physical TPM
+
+If using a physical TPM for the tests, the required ECDAA signing key can
+be created and loaded in the TPM using a test program in the `xaptum-tpm` project
+if you built that project from source:
+```bash
+# Use the copy of the xaptum-tpm project
+cd xaptum-tpm/build/testBin
+
+# Run the key-creation program
+./create_load_evict-test
+
+# Copy the output files to the test directory
+cp pub_key.txt ../../../test/tpm
+cp handle.txt ../../../test/tpm
+```
+
+The tests will now be able to use this key.
+
+NOTE: This program must only be run against a TPM on which you have Platform authorization,
+and which holds no important data.
+The preparation program runs `TPM2_Clear`!
+
+## Code Analysis Tools
+
+The continuous-integration build process also runs
+multiple code analysis tools.
+
+Test code coverage is measured using `gcov`, and monitored via `coveralls`.
+
+### Valgrind
+
+The Valgrind tool `memcheck` is used for heap memory checking.
+Every build on `travis-ci` runs this test.
+
+To run a `memcheck` test,
+configure and build the project as explained in [BUILDING.md](BUILDING.md),
+but also pass `-DCMAKE_BUILD_TYPE=RelWithDebInfo` to CMake during the configuration step.
+(if using `ECDAA_TPM_SUPPORT=ON`, also prepare the TPM as explained [above](#testing-tpm-support)).
+Then, in the build directory,
+run the tests using the `memcheck` tool and display the results:
+```bash
+## (benchmarks and fuzzing are excluded because they take too long under the Valgrind instrumentation)
+ctest -VV -E benchmark\|fuzz\|tool_test -T memcheck
+../test/valgrind-tool-test.sh ./build > ./Testing/Temporary/MemoryChecker.ToolTest.log 2>&1
+
+# Show the results
+../.travis/show-memcheck-results.sh $(pwd)
+```
+
+### Scan-build
+
+Clang's `scan-build` tool is a general static analyzer, run every build on `travis-ci`.
+
+The `scan-build` tool can be run locally by doing the following
+(if building dependencies from source, make sure to do that first):
+```bash
+./.travis/run-scanbuild.sh . ./build
+```
+
+### cppcheck
+
+The `cppcheck` static analyzer is also available, and is run every build on `travis-ci`.
+To run it do the following:
+
+```bash
+./.travis/run-cppcheck.sh . ./build
+```
+
+This tool is generally considered to have a lower false-positive rate than
+many other static analyzers, though with that comes a potential loss of strictness.
+
+### Address and Undefined Behavior Sanitizers
+
+Google produced "sanitizer" tools (code instrumenters that check for errors
+while running, and thus "dynamically") for checking memory use and
+code that may produce undefined behavior.
+These sanitizers are now part of both the Clang and GCC compilers.
+The address sanitizer and undefined behavior sanitizer
+(including the unsigned-int-overflow sanitizer) are run for every build on `travis-ci`.
+
+To run tests using these sanitizers,
+configure and build the project as explained in [BUILDING.md](BUILDING.md),
+but also pass `-DCMAKE_BUILD_TYPE=RelWithSanitize` to CMake during the configuration step.
+(if using `ECDAA_TPM_SUPPORT=ON`, also prepare the TPM as explained [above](#testing-tpm-support)).
+Then, in the build directory,
+run the tests (the instrumentation has been built into the executables):
+```bash
+## (benchmarks are excluded because they take too long under the sanitizer instrumentation)
+ctest -VV -E benchmark
+```
+
+### Coverity
+
+Coverity static analysis is run after any push to the `coverity_scan` branch.
+Coverity is a static analyzer provided by Synopsys, and the reports
+for this project can be found by clicking the Coverity link at the top of [README](../README.md).
+

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -1,0 +1,285 @@
+# Using the Libraries
+
+The top-level header to include is `ecdaa.h`,
+and the name of the library is `libecdaa`.
+
+## API Conventions
+
+All API functions exist in the `ecdaa` namespace,
+and are focused on a small number of basic `structs` (e.g. `signature`).
+Function names take the form `ecdaa_<struct-name>[_TPM]_<curve-name>_<action>`,
+where `_TPM` is only present for versions that use a TPM (see below).
+For example, for generating a credential when using the BN254 curve-type, the function
+to use is `ecdaa_credential_BN254_generate`.
+
+Output parameters are frequently used in the API functions, and come at the beginning
+of the parameter list.
+
+The fundamental structs have (de-)serialization functions,
+and macros and functions giving their serialized length.
+Again, the format of the serialized length macro/function is
+`ecdaa_<struct-name>_<curve-name>_length` (capitalized for the macro).
+
+Success is indicated by a `0` return value.
+Each function defines its own non-zero error return values
+(documented in the relevant header file).
+
+Raw buffers (for input and output) are always `uint8_t*` types.
+When the length of a buffer is unknown (in most cases, the buffer structure
+is statically known), the length is given by a `uint32_t`.
+
+## Cryptographically-secure Random Numbers
+
+Many of the functions provided by this library (particularly, those used by an Issuer or a Member)
+require a source of cryptographically-secure random numbers.
+
+**The security of this library depends critically on these random numbers**.
+
+Such functions take a parameter of type `ecdaa_rand_func`,
+which is a function pointer for a function that will fill a buffer with a given
+number of random bytes.
+The expectation is that this function will use the system's source of randomness
+(e.g. `getrandom` on Linux, `getentropy` on OpenBSD, `arc4random` on Mac OS X,
+`RtlGenRandom` on Windows, or reading from `/dev/urandom` when these others aren't available).
+Note that a `ecdaa_rand_func` will never be called with a request larger than 255 bytes
+(so functions like `getrandom` and `getentropy` that have such a limit are OK to use).
+Examples of such usage can be found in the implementation of the example programs,
+in `examples/examples_rand.c`.
+
+The easiest way to satisfy the requirements of the `ecdaa_rand_func` on systems supported by
+the libsodium library is to use
+the libsodium function `randombytes_buf`.
+
+## Code Examples
+
+In these examples, `ZZZ` is a placeholder for the pairing-friendly curve,
+and `rand_func` is an instance of `ecdaa_rand_func` (see above).
+
+### Creating a New DAA Group
+
+When acting as the Issuer, define a new DAA Group by
+creating a new Issuer public/secret key pair
+(the public/secret key pair is used for adding new members to the group
+during the Join process, and the public key also contains the group public key).
+
+```bash
+<Issuer>
+struct ecdaa_issuer_public_key_ZZZ ipk;
+struct ecdaa_issuer_secret_key_ZZZ isk;
+ecdaa_issuer_key_pair_ZZZ_generate(&ipk, &isk, rand_func));
+```
+
+### Join Process
+
+A Member starts the Join process to be granted membership in the DAA group.
+
+The Join process begins with the Member requesting a nonce and issuer public key from the Issuer.
+This process is outside the scope of this project.
+
+Once the Member obtains a nonce and issuer public key from the Issuer, the Member
+first extracts the group public key from the issuer public key.
+
+```bash
+<Member>
+struct ecdaa_issuer_public_key_ZZZ ipk;
+... read the issuer's serialized public key into input_buffer ...
+ret = ecdaa_issuer_public_key_ZZZ_deserialize(&ipk, input_buffer);
+... if ret is non-zero, issuer's key is malformed or invalid ...
+```
+
+If the extraction succeeds (indicating the Issuer is honest), the Member saves the
+group public key (available in `ipk.gpk`).
+
+Next, the member uses the nonce to
+generate its public/secret key-pair
+(and a signature proving possession of the secret key).
+
+```bash
+<Member>
+ecdaa_member_request_join nonce-text pk.bin sk.bin
+struct ecdaa_member_public_key_ZZZ pk;
+struct ecdaa_member_secret_key_ZZZ sk;
+ecdaa_member_key_pair_ZZZ_generate(&pk, &sk, nonce, nonce_length, rand_func);
+```
+
+The Member sends its public key (along with the signature generated alongside it)
+to the Issuer,
+who then uses it (along with its secret key and the nonce
+it originally gave to this Member) to
+check the validity of the Member's
+public key.
+
+```bash
+<Issuer>
+struct ecdaa_member_public_key_ZZZ pk;
+... read the members's serialized public key (and signature) into input_buffer ...
+ret = ecdaa_member_public_key_ZZZ_deserialize(&pk, input_buffer, nonce, nonce_len);
+... if ret is non-zero, member's key is malformed or invalid ...
+```
+
+The Issuer now generates a DAA credential and credential-signature,
+which the Issuer sends back to the Member.
+
+```bash
+<Issuer>
+... retrieve issuer secret key into isk ...
+struct ecdaa_credential_ZZZ cred;
+struct ecdaa_credential_ZZZ_signature cred_sig;
+ecdaa_credential_ZZZ_generate(&cred, &cred_sig, &isk, &pk, rand_func);
+```
+
+Once it gets the credential (and signature) from the Issuer,
+the Member uses the credential and credential-signature
+(along with its own public key and the group public key that it extracted earlier)
+to check the validity of the Issuer's credential-signature.
+
+```bash
+<Member>
+... retrieve member's public key into pk ...
+... retrieve group public key into gpk ...
+... read the credential into cred_buffer and the credential-signature into sig_buffer ...
+ret = ecdaa_credential_ZZZ_deserialize_with_signature(&cred, &pk, &gpk, cred_buffer, sig_buffer)
+... if ret is non-zero, the credential can't be trusted ...
+```
+
+If the credential-signature check succeeds, the Member saves the credential
+along with its secret key (its public key is no longer needed).
+The credential and the member's secret key will be used to create DAA signatures.
+
+### Signing and Verifying
+
+Any Verifier wishing to verfiy DAA signatures for a DAA group
+first obtains the issuer public key for this group, from the pertinent Issuer.
+The Verifier then extracts the group public key from this issuer public key,
+as described in the previous section.
+If the extraction succeeds (indicating the Issuer was honest),
+the Verifier saves the group public key for all later verifications.
+
+Verifiers also maintain a secret key revocation list, which lists
+DAA secret keys that are known to have been compromised.
+The issuer may be involved in communicating this list to
+all verifiers.
+This process is outside the scope of this project.
+
+Also outside the scope of this project,
+the Verifiers and Members decide whether to use
+pseudonym linking ("basename signatures").
+Pseudonyms allow a specific Verifier (identified by a basename)
+to link separate signatures from the same Member.
+Without pseudonym-linking, every signature (no matter from whom)
+is cryptographically un-linkable to any other signature.
+Pseudonym-linking also allows a Verifier to revoke a Member
+based only on their signature (i.e. without having knowledge
+of their secret key, as required with a secret key revocation).
+It's up to the specific use-case whether or not pseudonyms
+should be used.
+
+A member creates a DAA signature over a message
+by passing its secret key and its credential,
+along with the message to be signed and the basename
+(if pseudonym linking is required by the Verifier),
+to the `ecdaa_signature_ZZZ_sign` function.
+This outputs a DAA signature, which the Member
+sends (along with some indication of the DAA group
+it is claiming) to a Verifier.
+
+```bash
+... retrieve member secret into sk ...
+... retrieve credential into cred ...
+struct ecdaa_signature_FP256BN sig;
+ecdaa_signature_ZZZ_sign(&sig, message, msg_len, basename, basename_len, &sk, &cred, rand_func);
+```
+
+The Verifier looks up the group public key (extracted earlier)
+and the basename (if using pseudonym linking)
+for the DAA group claimed by the Signer.
+It passes this group public key and the secret key (and potentially pseudonym) revocation list(s) for this DAA group,
+along with the message and signature,
+to the `ecdaa_verify` command.
+
+```bash
+... read the member's signature into sig ...
+... retrieve the claimed group public into gpk ...
+... retrieve the necessary basename string into basename ...
+struct ecdaa_revocations_FP256BN revocations;
+... retrieve any secret key revocations into revocations.sk_list ...
+... retrieve any pseudonym ("basename") revocations into revocations.bsn_list ...
+ecdaa_signature_ZZZ_verify(&sig, &gpk, &revocations, message, msg_len, basename, basename_len);
+```
+
+If the signature is valid, this function returns `0`.
+
+## Example Programs
+
+The `examples` directory contains fully-functional example code for using the library
+(without TPM support),
+where for simplicity communication between the Issuer, Member, and Verifier
+is done using regular files.
+
+The example programs use the FP256BN curve type.
+
+NOTE: If using these example programs on a system where `/dev/urandom` is the only
+option for cryptographically-secure random numbers
+(cf. `/examples/ecdaa_examples_randomness.c`),
+the proper seeding of `/dev/urandom`
+(i.e. the amount of entropy available) is not checked!
+Thus, in such situations, these programs are not safe to use in situations
+where the system random number generator may not be seeded
+(e.g. early in the boot process on some systems).
+The example programs must be carefully adapted for use in such situations.
+
+## Using a TPM
+
+Signatures can be created with the help of a Trusted Platform Module (TPM),
+if hardware-based security of the member's credentials is required.
+
+To use the TPM-enabled functionality,
+include the top-level header `ecdaa-tpm.h`,
+and the name of the library is `libecdaa-tpm`;
+these must be used *in addition* to the regular `ecdaa` header and library
+described above.
+
+This implementation has been tested against the following TCG TPM2.0 specifications:
+- Specification v1.38
+- Specification v1.16 with Errata v1.5
+
+A signing key must first be created and loaded in the TPM.
+This key must be created with the following properties
+(consult the [TPM documentation](https://trustedcomputinggroup.org/resource/tpm-library-specification/)
+or a [TPM TSS implementation](https://github.com/tpm2-software/tpm2-tss)
+for an explanation of how to create an asymmetric signing key):
+- `sign` attribute must be set
+- `restricted` attribute must NOT be set
+- `userWithAuth` attribute must be set
+  - The authorization must be a (possibly empty) password
+- `scheme = TPM_ALG_ECDAA`
+- `hashAlg = TPM_ALG_SHA256`
+- `curveID = TPM_ECC_BN_P256`
+
+For this library to communicate with the TPM,
+ an `ecdaa_tpm_context` object must be created.
+Here, 
+```
+struct ecdaa_tpm_context tpm_context;
+TSS2_TCTI_CONTEXT tcti_context;
+... initialize the TCTI_CONTEXT, as explained by your TSS implementation ...
+ecdaa_tpm_context_init(&tpm_context, key_handle, password, password_length, &tcti_context);
+```
+where `key_handle` is the TPM handle of
+the TPM signing key, and `password` is the TPM authorization associated with that key.
+NOTE: Once this `ecdaa_tpm_context` is no longer needed,
+it must be freed using `ecdaa_tpm_context_free`.
+
+The DAA "join" process proceeds as usual (i.e. as when not using a TPM), with the
+change that `ecdaa_member_key_pair_TPM_FP256BN_generate` must be used in place of
+`ecdaa_member_key_pair_FP256BN_generate`.
+
+An ECDAA signature using this TPM-generated secret key is then created using:
+```
+struct ecdaa_signature_TPM_FP256BN signature;
+ecdaa_signature_TPM_FP256BN_sign(&signature, msg, msg_length, basename, basename_length, &credential, &prng, &tpm_context);
+```
+where `credential`, `prng`, and `basename` are as when not using a TPM.
+
+Notice that verification of a TPM-generated signature proceeds as usual, using `ecdaa_signature_FP256BN_verify`.
+

--- a/libecdaa/credential_ZZZ.c
+++ b/libecdaa/credential_ZZZ.c
@@ -269,10 +269,12 @@ int ecdaa_credential_ZZZ_deserialize_with_signature_file(struct ecdaa_credential
                                                     const char *credential_signature_file)
 {
     FILE *cred_file_ptr = fopen(credential_file, "rb");
+    if (NULL == cred_file_ptr) {
+        return READ_FROM_FILE_ERROR;
+    }
     FILE *cred_sig_file_ptr = fopen(credential_signature_file, "rb");
-
-
-    if (NULL == cred_file_ptr || NULL == cred_sig_file_ptr){
+    if (NULL == cred_sig_file_ptr) {
+        fclose(cred_file_ptr);
         return READ_FROM_FILE_ERROR;
     }
 

--- a/libecdaa/credential_ZZZ.c
+++ b/libecdaa/credential_ZZZ.c
@@ -169,21 +169,13 @@ void ecdaa_credential_ZZZ_serialize(uint8_t *buffer_out,
 int ecdaa_credential_ZZZ_serialize_file(const char* file,
                                     struct ecdaa_credential_ZZZ *credential)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_CREDENTIAL_ZZZ_LENGTH] = {0};
+    ecdaa_credential_ZZZ_serialize(buffer, credential);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_CREDENTIAL_ZZZ_LENGTH);
+    if (ECDAA_CREDENTIAL_ZZZ_LENGTH != write_ret) {
+        return write_ret;
     }
-
-    int ret = ecdaa_credential_ZZZ_serialize_fp(file_ptr, credential);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_credential_ZZZ_serialize_fp(FILE* fp,
@@ -193,7 +185,7 @@ int ecdaa_credential_ZZZ_serialize_fp(FILE* fp,
     ecdaa_credential_ZZZ_serialize(buffer, credential);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_CREDENTIAL_ZZZ_LENGTH);
     if (ECDAA_CREDENTIAL_ZZZ_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
     return SUCCESS;
 }
@@ -208,21 +200,13 @@ void ecdaa_credential_ZZZ_signature_serialize(uint8_t *buffer_out,
 int ecdaa_credential_ZZZ_signature_serialize_file(const char* file,
                                               struct ecdaa_credential_ZZZ_signature *cred_sig)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH] = {0};
+    ecdaa_credential_ZZZ_signature_serialize(buffer, cred_sig);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH);
+    if (ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH != write_ret) {
+        return write_ret;
     }
-
-    int ret = ecdaa_credential_ZZZ_signature_serialize_fp(file_ptr, cred_sig);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_credential_ZZZ_signature_serialize_fp(FILE* fp,
@@ -232,7 +216,7 @@ int ecdaa_credential_ZZZ_signature_serialize_fp(FILE* fp,
     ecdaa_credential_ZZZ_signature_serialize(buffer, cred_sig);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH);
     if (ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
     return SUCCESS;
 }
@@ -268,25 +252,23 @@ int ecdaa_credential_ZZZ_deserialize_with_signature_file(struct ecdaa_credential
                                                     const char *credential_file,
                                                     const char *credential_signature_file)
 {
-    FILE *cred_file_ptr = fopen(credential_file, "rb");
-    if (NULL == cred_file_ptr) {
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_CREDENTIAL_ZZZ_LENGTH + ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH] = {0};
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_CREDENTIAL_ZZZ_LENGTH, credential_file);
+    if (ECDAA_CREDENTIAL_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
-    FILE *cred_sig_file_ptr = fopen(credential_signature_file, "rb");
-    if (NULL == cred_sig_file_ptr) {
-        fclose(cred_file_ptr);
-        return READ_FROM_FILE_ERROR;
+    read_ret = ecdaa_read_from_file(buffer + ECDAA_CREDENTIAL_ZZZ_LENGTH,
+                                    ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH,
+                                    credential_signature_file);
+    if (ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH != read_ret) {
+        return read_ret;
     }
-
-    int ret = ecdaa_credential_ZZZ_deserialize_with_signature_fp(credential_out, pk, gpk, cred_file_ptr, cred_sig_file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(cred_file_ptr) && 0 != fclose(cred_sig_file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int deserialize_ret = ecdaa_credential_ZZZ_deserialize_with_signature(credential_out, pk, gpk, buffer, buffer + ECDAA_CREDENTIAL_ZZZ_LENGTH);
+    if (0 != deserialize_ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
 
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_credential_ZZZ_deserialize_with_signature_fp(struct ecdaa_credential_ZZZ *credential_out,
@@ -298,13 +280,13 @@ int ecdaa_credential_ZZZ_deserialize_with_signature_fp(struct ecdaa_credential_Z
     uint8_t buffer[ECDAA_CREDENTIAL_ZZZ_LENGTH + ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH] = {0};
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_CREDENTIAL_ZZZ_LENGTH, credential_file);
     if (ECDAA_CREDENTIAL_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     read_ret = ecdaa_read_from_fp(buffer + ECDAA_CREDENTIAL_ZZZ_LENGTH,
                                     ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH,
                                     credential_signature_file);
     if (ECDAA_CREDENTIAL_ZZZ_SIGNATURE_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     int deserialize_ret = ecdaa_credential_ZZZ_deserialize_with_signature(credential_out, pk, gpk, buffer, buffer + ECDAA_CREDENTIAL_ZZZ_LENGTH);
     if (0 != deserialize_ret) {
@@ -337,21 +319,16 @@ int ecdaa_credential_ZZZ_deserialize(struct ecdaa_credential_ZZZ *credential_out
 int ecdaa_credential_ZZZ_deserialize_file(struct ecdaa_credential_ZZZ *credential_out,
                                      const char* file)
 {
-    FILE *file_ptr = fopen(file, "rb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_CREDENTIAL_ZZZ_LENGTH] = {0};
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_CREDENTIAL_ZZZ_LENGTH, file);
+    if (ECDAA_CREDENTIAL_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
-
-    int ret = ecdaa_credential_ZZZ_deserialize_fp(credential_out, file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int ret = ecdaa_credential_ZZZ_deserialize(credential_out, buffer);
+    if (0 != ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_credential_ZZZ_deserialize_fp(struct ecdaa_credential_ZZZ *credential_out,
@@ -360,7 +337,7 @@ int ecdaa_credential_ZZZ_deserialize_fp(struct ecdaa_credential_ZZZ *credential_
     uint8_t buffer[ECDAA_CREDENTIAL_ZZZ_LENGTH] = {0};
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_CREDENTIAL_ZZZ_LENGTH, fp);
     if (ECDAA_CREDENTIAL_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     int ret = ecdaa_credential_ZZZ_deserialize(credential_out, buffer);
     if (0 != ret) {

--- a/libecdaa/group_public_key_ZZZ.c
+++ b/libecdaa/group_public_key_ZZZ.c
@@ -37,21 +37,13 @@ void ecdaa_group_public_key_ZZZ_serialize(uint8_t *buffer_out,
 int ecdaa_group_public_key_ZZZ_serialize_file(const char* file,
                                           struct ecdaa_group_public_key_ZZZ *gpk)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH] = {0};
+    ecdaa_group_public_key_ZZZ_serialize(buffer, gpk);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH);
+    if (ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH != write_ret) {
+        return write_ret;
     }
-
-    int ret = ecdaa_group_public_key_ZZZ_serialize_fp(file_ptr, gpk);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_group_public_key_ZZZ_serialize_fp(FILE* fp,
@@ -61,7 +53,7 @@ int ecdaa_group_public_key_ZZZ_serialize_fp(FILE* fp,
     ecdaa_group_public_key_ZZZ_serialize(buffer, gpk);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH);
     if (ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
     return SUCCESS;
 }
@@ -83,21 +75,18 @@ int ecdaa_group_public_key_ZZZ_deserialize(struct ecdaa_group_public_key_ZZZ *gp
 int ecdaa_group_public_key_ZZZ_deserialize_file(struct ecdaa_group_public_key_ZZZ *gpk_out,
                                            const char* file)
 {
-    FILE *file_ptr = fopen(file, "rb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH] = {0};
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH, file);
+    if (ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
 
-    int ret = ecdaa_group_public_key_ZZZ_deserialize_fp(gpk_out, file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int ret = ecdaa_group_public_key_ZZZ_deserialize(gpk_out, buffer);
+    if (0 != ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
 
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_group_public_key_ZZZ_deserialize_fp(struct ecdaa_group_public_key_ZZZ *gpk_out,
@@ -106,7 +95,7 @@ int ecdaa_group_public_key_ZZZ_deserialize_fp(struct ecdaa_group_public_key_ZZZ 
     uint8_t buffer[ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH] = {0};
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH, fp);
     if (ECDAA_GROUP_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
 
     int ret = ecdaa_group_public_key_ZZZ_deserialize(gpk_out, buffer);

--- a/libecdaa/issuer_keypair_ZZZ.c
+++ b/libecdaa/issuer_keypair_ZZZ.c
@@ -82,21 +82,15 @@ void ecdaa_issuer_public_key_ZZZ_serialize(uint8_t *buffer_out,
 int ecdaa_issuer_public_key_ZZZ_serialize_file(const char* file,
                                            struct ecdaa_issuer_public_key_ZZZ *ipk)
 {
-    FILE *file_ptr = fopen(file, "wb");
+    uint8_t buffer[ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
+    ecdaa_issuer_public_key_ZZZ_serialize(buffer, ipk);
 
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH);
+    if (ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH != write_ret) {
+        return write_ret;
     }
 
-    int ret = ecdaa_issuer_public_key_ZZZ_serialize_fp(file_ptr, ipk);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_issuer_public_key_ZZZ_serialize_fp(FILE* fp,
@@ -107,7 +101,7 @@ int ecdaa_issuer_public_key_ZZZ_serialize_fp(FILE* fp,
 
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH);
     if (ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
 
     return SUCCESS;
@@ -140,21 +134,17 @@ int ecdaa_issuer_public_key_ZZZ_deserialize(struct ecdaa_issuer_public_key_ZZZ *
 int ecdaa_issuer_public_key_ZZZ_deserialize_file(struct ecdaa_issuer_public_key_ZZZ *ipk_out,
                                             const char* file)
 {
-    FILE *file_ptr = fopen(file, "rb");
+    uint8_t buffer[ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
 
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH, file);
+    if (ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
+    int deserialize_ret = ecdaa_issuer_public_key_ZZZ_deserialize(ipk_out, buffer);
+    if (0 != deserialize_ret)
+        return DESERIALIZE_KEY_ERROR;
 
-    int ret = ecdaa_issuer_public_key_ZZZ_deserialize_fp(ipk_out, file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_issuer_public_key_ZZZ_deserialize_fp(struct ecdaa_issuer_public_key_ZZZ *ipk_out,
@@ -164,7 +154,7 @@ int ecdaa_issuer_public_key_ZZZ_deserialize_fp(struct ecdaa_issuer_public_key_ZZ
 
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH, fp);
     if (ECDAA_ISSUER_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     int deserialize_ret = ecdaa_issuer_public_key_ZZZ_deserialize(ipk_out, buffer);
     if (0 != deserialize_ret)
@@ -182,21 +172,14 @@ void ecdaa_issuer_secret_key_ZZZ_serialize(uint8_t *buffer_out,
 
 int ecdaa_issuer_secret_key_ZZZ_serialize_file(const char* file, struct ecdaa_issuer_secret_key_ZZZ *isk)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH] = {0};
+    ecdaa_issuer_secret_key_ZZZ_serialize(buffer, isk);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH);
+    if (ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH != write_ret) {
+        return write_ret;
     }
 
-    int ret = ecdaa_issuer_secret_key_ZZZ_serialize_fp(file_ptr, isk);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_issuer_secret_key_ZZZ_serialize_fp(FILE* fp, struct ecdaa_issuer_secret_key_ZZZ *isk)
@@ -205,7 +188,7 @@ int ecdaa_issuer_secret_key_ZZZ_serialize_fp(FILE* fp, struct ecdaa_issuer_secre
     ecdaa_issuer_secret_key_ZZZ_serialize(buffer, isk);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH);
     if (ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
 
     return SUCCESS;
@@ -223,21 +206,19 @@ int ecdaa_issuer_secret_key_ZZZ_deserialize(struct ecdaa_issuer_secret_key_ZZZ *
 int ecdaa_issuer_secret_key_ZZZ_deserialize_file(struct ecdaa_issuer_secret_key_ZZZ *isk_out,
                                             const char* file)
 {
-    FILE *file_ptr = fopen(file, "rb");
+    uint8_t buffer[ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH] = {0};
 
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH, file);
+    if (ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
 
-    int ret = ecdaa_issuer_secret_key_ZZZ_deserialize_fp(isk_out, file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int deserialize_ret = ecdaa_issuer_secret_key_ZZZ_deserialize(isk_out, buffer);
+    if (0 != deserialize_ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
 
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_issuer_secret_key_ZZZ_deserialize_fp(struct ecdaa_issuer_secret_key_ZZZ *isk_out,
@@ -247,7 +228,7 @@ int ecdaa_issuer_secret_key_ZZZ_deserialize_fp(struct ecdaa_issuer_secret_key_ZZ
 
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH, fp);
     if (ECDAA_ISSUER_SECRET_KEY_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
 
     int deserialize_ret = ecdaa_issuer_secret_key_ZZZ_deserialize(isk_out, buffer);

--- a/libecdaa/member_keypair_ZZZ.c
+++ b/libecdaa/member_keypair_ZZZ.c
@@ -98,21 +98,13 @@ void ecdaa_member_public_key_ZZZ_serialize(uint8_t *buffer_out,
 int ecdaa_member_public_key_ZZZ_serialize_file(const char* file,
                                            struct ecdaa_member_public_key_ZZZ *pk)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
+    ecdaa_member_public_key_ZZZ_serialize(buffer, pk);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH);
+    if (ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH != write_ret) {
+        return write_ret;
     }
-
-    int ret = ecdaa_member_public_key_ZZZ_serialize_fp(file_ptr, pk);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_member_public_key_ZZZ_serialize_fp(FILE* fp,
@@ -122,7 +114,7 @@ int ecdaa_member_public_key_ZZZ_serialize_fp(FILE* fp,
     ecdaa_member_public_key_ZZZ_serialize(buffer, pk);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH);
     if (ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
     return SUCCESS;
 }
@@ -155,21 +147,16 @@ int ecdaa_member_public_key_ZZZ_deserialize_file(struct ecdaa_member_public_key_
                                             uint8_t *nonce,
                                             uint32_t nonce_len)
 {
-    FILE *file_ptr = fopen(file, "rb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH, file);
+    if (ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
-
-    int ret = ecdaa_member_public_key_ZZZ_deserialize_fp(pk_out, file_ptr, nonce, nonce_len);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int deserialize_ret = ecdaa_member_public_key_ZZZ_deserialize(pk_out, buffer, (uint8_t*)nonce, (uint32_t)nonce_len);
+    if (0 != deserialize_ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_member_public_key_ZZZ_deserialize_fp(struct ecdaa_member_public_key_ZZZ *pk_out,
@@ -180,7 +167,7 @@ int ecdaa_member_public_key_ZZZ_deserialize_fp(struct ecdaa_member_public_key_ZZ
     uint8_t buffer[ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH, file);
     if (ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     int deserialize_ret = ecdaa_member_public_key_ZZZ_deserialize(pk_out, buffer, (uint8_t*)nonce, (uint32_t)nonce_len);
     if (0 != deserialize_ret) {
@@ -210,21 +197,18 @@ int ecdaa_member_public_key_ZZZ_deserialize_no_check(struct ecdaa_member_public_
 int ecdaa_member_public_key_ZZZ_deserialize_no_check_file(struct ecdaa_member_public_key_ZZZ *pk_out,
                                                      const char *file)
 {
-    FILE *file_ptr = fopen(file, "rb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH, file);
+    if (ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
 
-    int ret = ecdaa_member_public_key_ZZZ_deserialize_no_check_fp(pk_out, file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int ret = ecdaa_member_public_key_ZZZ_deserialize_no_check(pk_out, buffer);
+    if (0 != ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
 
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_member_public_key_ZZZ_deserialize_no_check_fp(struct ecdaa_member_public_key_ZZZ *pk_out,
@@ -233,7 +217,7 @@ int ecdaa_member_public_key_ZZZ_deserialize_no_check_fp(struct ecdaa_member_publ
     uint8_t buffer[ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH] = {0};
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH, file);
     if (ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
 
     int ret = ecdaa_member_public_key_ZZZ_deserialize_no_check(pk_out, buffer);
@@ -253,21 +237,13 @@ void ecdaa_member_secret_key_ZZZ_serialize(uint8_t *buffer_out,
 int ecdaa_member_secret_key_ZZZ_serialize_file(const char* file,
                                            struct ecdaa_member_secret_key_ZZZ *sk)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH] = {0};
+    ecdaa_member_secret_key_ZZZ_serialize(buffer, sk);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH);
+    if (ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH != write_ret) {
+        return write_ret;
     }
-
-    int ret = ecdaa_member_secret_key_ZZZ_serialize_fp(file_ptr, sk);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_member_secret_key_ZZZ_serialize_fp(FILE* fp,
@@ -277,7 +253,7 @@ int ecdaa_member_secret_key_ZZZ_serialize_fp(FILE* fp,
     ecdaa_member_secret_key_ZZZ_serialize(buffer, sk);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH);
     if (ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
     return SUCCESS;
 }
@@ -293,21 +269,16 @@ int ecdaa_member_secret_key_ZZZ_deserialize(struct ecdaa_member_secret_key_ZZZ *
 int ecdaa_member_secret_key_ZZZ_deserialize_file(struct ecdaa_member_secret_key_ZZZ *sk_out,
                                             const char* file)
 {
-    FILE *file_ptr = fopen(file, "rb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH] = {0};
+    int read_ret = ecdaa_read_from_file(buffer, ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH, file);
+    if (ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH != read_ret) {
+        return read_ret;
     }
-
-    int ret = ecdaa_member_secret_key_ZZZ_deserialize_fp(sk_out, file_ptr);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    int ret = ecdaa_member_secret_key_ZZZ_deserialize(sk_out, buffer);
+    if (0 != ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_member_secret_key_ZZZ_deserialize_fp(struct ecdaa_member_secret_key_ZZZ *sk_out,
@@ -316,7 +287,7 @@ int ecdaa_member_secret_key_ZZZ_deserialize_fp(struct ecdaa_member_secret_key_ZZ
     uint8_t buffer[ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH] = {0};
     int read_ret = ecdaa_read_from_fp(buffer, ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH, fp);
     if (ECDAA_MEMBER_SECRET_KEY_ZZZ_LENGTH != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     int ret = ecdaa_member_secret_key_ZZZ_deserialize(sk_out, buffer);
     if (0 != ret) {

--- a/libecdaa/signature_ZZZ.c
+++ b/libecdaa/signature_ZZZ.c
@@ -174,21 +174,20 @@ int ecdaa_signature_ZZZ_serialize_file(const char* file,
                                    struct ecdaa_signature_ZZZ *signature,
                                    int has_nym)
 {
-    FILE *file_ptr = fopen(file, "wb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH];
+    uint32_t sig_length = 0;
+    if (has_nym) {
+        sig_length = ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH;
+    } else {
+        sig_length = ECDAA_SIGNATURE_ZZZ_LENGTH;
+    }
+    ecdaa_signature_ZZZ_serialize(buffer, signature, has_nym);
+    int write_ret = ecdaa_write_buffer_to_file(file, buffer, sig_length);
+    if ((int)sig_length != write_ret) {
+        return write_ret;
     }
 
-    int ret = ecdaa_signature_ZZZ_serialize_fp(file_ptr, signature, has_nym);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_signature_ZZZ_serialize_fp(FILE* fp,
@@ -205,7 +204,7 @@ int ecdaa_signature_ZZZ_serialize_fp(FILE* fp,
     ecdaa_signature_ZZZ_serialize(buffer, signature, has_nym);
     int write_ret = ecdaa_write_buffer_to_fp(fp, buffer, sig_length);
     if ((int)sig_length != write_ret) {
-        return WRITE_TO_FILE_ERROR;
+        return write_ret;
     }
 
     return SUCCESS;
@@ -248,21 +247,23 @@ int ecdaa_signature_ZZZ_deserialize_file(struct ecdaa_signature_ZZZ *signature_o
                                         const char *file,
                                         int has_nym)
 {
-    FILE *file_ptr = fopen(file, "rb");
-
-    if (NULL == file_ptr){
-        return READ_FROM_FILE_ERROR;
+    uint8_t buffer[ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH];
+    uint32_t sig_length = 0;
+    if (has_nym) {
+        sig_length = ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH;
+    } else {
+        sig_length = ECDAA_SIGNATURE_ZZZ_LENGTH;
+    }
+    int read_ret = ecdaa_read_from_file(buffer, sig_length, file);
+    if ((int)sig_length != read_ret) {
+        return read_ret;
+    }
+    int ret = ecdaa_signature_ZZZ_deserialize(signature_out, buffer, has_nym);
+    if (0 != ret) {
+        return DESERIALIZE_KEY_ERROR;
     }
 
-    int ret = ecdaa_signature_ZZZ_deserialize_fp(signature_out, file_ptr, has_nym);
-
-    if (ret >= 0) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
-    }
-
-    return ret;
+    return SUCCESS;
 }
 
 int ecdaa_signature_ZZZ_deserialize_fp(struct ecdaa_signature_ZZZ *signature_out,
@@ -278,7 +279,7 @@ int ecdaa_signature_ZZZ_deserialize_fp(struct ecdaa_signature_ZZZ *signature_out
     }
     int read_ret = ecdaa_read_from_fp(buffer, sig_length, fp);
     if ((int)sig_length != read_ret) {
-        return READ_FROM_FILE_ERROR;
+        return read_ret;
     }
     int ret = ecdaa_signature_ZZZ_deserialize(signature_out, buffer, has_nym);
     if (0 != ret) {

--- a/libecdaa/util/file_io.c
+++ b/libecdaa/util/file_io.c
@@ -30,10 +30,8 @@ int ecdaa_read_from_file(unsigned char *buffer, size_t bytes_to_read, const char
 
     int ret = ecdaa_read_from_fp(buffer, bytes_to_read, file_ptr);
 
-    if (ret >= 0 && bytes_to_read == (size_t)ret) {
-        if (0 != fclose(file_ptr)) {
-            return READ_FROM_FILE_ERROR;
-        }
+    if (0 != fclose(file_ptr)) {
+        return READ_FROM_FILE_ERROR;
     }
 
     return ret;
@@ -49,10 +47,8 @@ int ecdaa_write_buffer_to_file(const char *filename, uint8_t *buffer, size_t byt
 
     int ret = ecdaa_write_buffer_to_fp(file_ptr, buffer, bytes_to_write);
 
-    if (ret >= 0 && bytes_to_write == (size_t)ret) {
-        if (0 != fclose(file_ptr)) {
-            return WRITE_TO_FILE_ERROR;
-        }
+    if (0 != fclose(file_ptr)) {
+        return WRITE_TO_FILE_ERROR;
     }
 
     return ret;
@@ -66,12 +62,15 @@ int ecdaa_read_from_fp(unsigned char *buffer, size_t bytes_to_read, FILE *file_p
 
     size_t bytes_read = fread(buffer, 1, bytes_to_read, file_ptr);
 
+    // If we were asked to read an unknown-length file (bytes_to_read > file-length)
+    //  then we better already have hit EOF.
     if (bytes_to_read != bytes_read && !feof(file_ptr)) {
        return READ_FROM_FILE_ERROR;
     }
 
-    fgetc(file_ptr);
-    if (!feof(file_ptr)){
+    // If we were asked to read a specific number of bytes (bytes_to_read == file-length)
+    //  then the file better be exactly bytes_to_read bytes long.
+    if (EOF != fgetc(file_ptr)){
         return READ_FROM_FILE_ERROR;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,5 +88,4 @@ set(CURRENT_TEST_BINARY_DIR ${CMAKE_BINARY_DIR}/testBin/)
 add_test(NAME "tool_test"
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tool-test.sh
   ${PROJECT_SOURCE_DIR}/build/tool
-  ${CURRENT_TEST_BINARY_DIR}
   )

--- a/test/ecp2_ZZZ-tests.c
+++ b/test/ecp2_ZZZ-tests.c
@@ -47,14 +47,14 @@ void g2_basepoint_not_inf()
     ECP2_ZZZ point;
     ecp2_ZZZ_set_to_generator(&point);
 
-    TEST_ASSERT(!point.inf);
+    TEST_ASSERT(0 == ECP2_ZZZ_isinf(&point));
 
     printf("\tsuccess\n");
 }
 
 static void g2_serialize_then_deserialize_basepoint()
 {
-    printf("Starting ecp2_ZZZ::g2_basepoint_not_inf...\n");
+    printf("Starting ecp2_ZZZ::g2_serialize_then_deserialize_basepoint...\n");
 
     ECP2_ZZZ point;
     ecp2_ZZZ_set_to_generator(&point);

--- a/test/ecp_ZZZ-tests.c
+++ b/test/ecp_ZZZ-tests.c
@@ -49,7 +49,7 @@ void g1_basepoint_not_inf()
     ECP_ZZZ point;
     ecp_ZZZ_set_to_generator(&point);
 
-    TEST_ASSERT(!point.inf);
+    TEST_ASSERT(0 == ECP_ZZZ_isinf(&point));
 
     printf("\tsuccess\n");
 }

--- a/test/issuer_keypair_ZZZ-tests.c
+++ b/test/issuer_keypair_ZZZ-tests.c
@@ -46,8 +46,8 @@ void issuer_secrets_are_valid()
     ecdaa_issuer_key_pair_ZZZ_generate(&pk1, &sk1, test_randomness);
 
     TEST_ASSERT(BIG_XXX_comp(sk1.x, sk1.y) != 0);
-    TEST_ASSERT(!pk1.gpk.X.inf);
-    TEST_ASSERT(!pk1.gpk.Y.inf);
+    TEST_ASSERT(0 == ECP2_ZZZ_isinf(&pk1.gpk.X));
+    TEST_ASSERT(0 == ECP2_ZZZ_isinf(&pk1.gpk.Y));
 
     struct ecdaa_issuer_secret_key_ZZZ sk2;
     struct ecdaa_issuer_public_key_ZZZ pk2;

--- a/test/member_keypair_ZZZ-tests.c
+++ b/test/member_keypair_ZZZ-tests.c
@@ -162,6 +162,9 @@ static void serialize_deserialize_public_no_check()
     struct ecdaa_member_public_key_ZZZ pk;
     ecp_ZZZ_set_to_generator(&pk.Q);
     ECP_ZZZ_mul(&pk.Q, sk);
+    BIG_XXX_zero(pk.c);
+    BIG_XXX_zero(pk.s);
+    BIG_XXX_zero(pk.n);
 
     uint8_t buffer[ECDAA_MEMBER_PUBLIC_KEY_ZZZ_LENGTH];
     ecdaa_member_public_key_ZZZ_serialize(buffer, &pk);
@@ -220,6 +223,9 @@ static void serialize_deserialize_public_no_check_file()
     struct ecdaa_member_public_key_ZZZ pk;
     ecp_ZZZ_set_to_generator(&pk.Q);
     ECP_ZZZ_mul(&pk.Q, sk);
+    BIG_XXX_zero(pk.c);
+    BIG_XXX_zero(pk.s);
+    BIG_XXX_zero(pk.n);
 
     TEST_ASSERT(0 == ecdaa_member_public_key_ZZZ_serialize_file(pk_file, &pk));
 
@@ -284,14 +290,16 @@ static void serialize_deserialize_public_no_check_fp()
     struct ecdaa_member_public_key_ZZZ pk;
     ecp_ZZZ_set_to_generator(&pk.Q);
     ECP_ZZZ_mul(&pk.Q, sk);
+    BIG_XXX_zero(pk.c);
+    BIG_XXX_zero(pk.s);
+    BIG_XXX_zero(pk.n);
 
     FILE *pk_fp = fopen(pk_file, "wb");
     TEST_ASSERT(NULL != pk_fp);
     TEST_ASSERT(0 == ecdaa_member_public_key_ZZZ_serialize_fp(pk_fp, &pk));
     fclose(pk_fp);
 
-    pk_fp = fopen(pk_file, "rb");
-    TEST_ASSERT(NULL != pk_fp);
+    pk_fp = fopen(pk_file, "rb"); TEST_ASSERT(NULL != pk_fp);
     struct ecdaa_member_public_key_ZZZ pk_deserialized;
     TEST_ASSERT(0 == ecdaa_member_public_key_ZZZ_deserialize_no_check_fp(&pk_deserialized, pk_fp));
     fclose(pk_fp);

--- a/test/member_keypair_ZZZ-tests.c
+++ b/test/member_keypair_ZZZ-tests.c
@@ -66,7 +66,7 @@ void member_secret_is_valid()
 
     TEST_ASSERT(0 == ecdaa_member_key_pair_ZZZ_generate(&pk1, &sk1, nonce, sizeof(nonce), test_randomness));
 
-    TEST_ASSERT(!pk1.Q.inf);
+    TEST_ASSERT(0 == ECP_ZZZ_isinf(&pk1.Q));
 
     struct ecdaa_member_secret_key_ZZZ sk2;
     struct ecdaa_member_public_key_ZZZ pk2;

--- a/test/schnorr_ZZZ-fuzz.c
+++ b/test/schnorr_ZZZ-fuzz.c
@@ -30,6 +30,9 @@
 #include <amcl/ecp_ZZZ.h>
 
 #include <string.h>
+#include <stdio.h>
+
+#define MAX_REPS 10000
 
 static void schnorr_repeated(int schnorr_repetitions);
 
@@ -38,6 +41,10 @@ int main(int argc, char *argv[])
     int schnorr_repetitions = 20;
     if (argc == 2) {
         schnorr_repetitions = atoi(argv[1]);
+        if (schnorr_repetitions < 1 || schnorr_repetitions > MAX_REPS) {
+            fprintf(stderr, "Invalid value '%s' pass to 'repetitions' argument\n", argv[1]);
+            return 1;
+        }
     }
 
     schnorr_repeated(schnorr_repetitions);

--- a/test/schnorr_ZZZ-tests.c
+++ b/test/schnorr_ZZZ-tests.c
@@ -75,8 +75,8 @@ void schnorr_keygen_sane()
     TEST_ASSERT(0 != BIG_XXX_comp(private_one, private_two));
     TEST_ASSERT(1 != ECP_ZZZ_equals(&public_one, &public_two));
 
-    TEST_ASSERT(!public_one.inf);
-    TEST_ASSERT(!public_two.inf);
+    TEST_ASSERT(0 == ECP_ZZZ_isinf(&public_one));
+    TEST_ASSERT(0 == ECP_ZZZ_isinf(&public_two));
 
     printf("\tsuccess\n");
 }

--- a/test/signature_ZZZ-tests.c
+++ b/test/signature_ZZZ-tests.c
@@ -214,6 +214,8 @@ static void lengths_same()
 
     TEST_ASSERT(ECDAA_SIGNATURE_ZZZ_LENGTH == ecdaa_signature_ZZZ_length());
 
+    TEST_ASSERT(ECDAA_SIGNATURE_ZZZ_WITH_NYM_LENGTH == ecdaa_signature_ZZZ_with_nym_length());
+
     printf("\tsuccess\n");
 }
 

--- a/test/tool-test.sh
+++ b/test/tool-test.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-if [[ $# -ne 2 ]]; then
-        echo "usage: $0 <tool directory> <tmp directory>"
+if [[ $# -ne 1 ]]; then
+        echo "usage: $0 <tool binary directory>"
         exit 1
 fi
 
 tool_dir="$1"
-tmp_dir="$2"
+tmp_dir=$(mktemp -d)
 
 echo "Generating issuer keys..."
 ${tool_dir}/ecdaa issuer genkeys -p ${tmp_dir}/ipk.bin -s ${tmp_dir}/isk.bin

--- a/test/valgrind-tool-test.sh
+++ b/test/valgrind-tool-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+if [[ $# -ne 1 ]]; then
+        echo "usage: $0 <tool binary directory>"
+        exit 1
+fi
+
+tool_dir="$1"
+tmp_dir=$(mktemp -d)
+
+echo "Generating issuer keys..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa issuer genkeys -p ${tmp_dir}/ipk.bin -s ${tmp_dir}/isk.bin
+
+echo "Generating member keys..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa member genkeys -p ${tmp_dir}/pk.bin -s ${tmp_dir}/sk.bin
+
+echo "Extracting issuer's group public key..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa extractgpk -p ${tmp_dir}/ipk.bin -g ${tmp_dir}/gpk.bin
+
+echo "Create a credential, and credential signature, on the member's public key..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa issuer issuecredential -p ${tmp_dir}/pk.bin -s ${tmp_dir}/isk.bin \
+        -c ${tmp_dir}/cred.bin -r ${tmp_dir}/cred_sig.bin
+
+echo "Validate a credential issued for the given member public key..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa member processcredential -p ${tmp_dir}/pk.bin -g ${tmp_dir}/gpk.bin -c \
+        ${tmp_dir}/cred.bin -r ${tmp_dir}/cred_sig.bin
+
+echo "ECDAATESTMESSAGE" > ${tmp_dir}/message.bin
+
+echo "Create a DAA signature over the message..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa member sign -s ${tmp_dir}/sk.bin -g ${tmp_dir}/sig.bin -c \
+        ${tmp_dir}/cred.bin -m ${tmp_dir}/message.bin
+
+echo "Verify the signature..."
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa verify -s ${tmp_dir}/sig.bin -g ${tmp_dir}/gpk.bin -m ${tmp_dir}/message.bin
+
+echo "Check that signature does NOT verify for a revoked secret key..."
+set +e
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa verify -s ${tmp_dir}/sig.bin -g ${tmp_dir}/gpk.bin -m ${tmp_dir}/message.bin \
+        -k ${tmp_dir}/sk.bin -e 1
+verify_rc=$?
+if [[ 1 -ne $verify_rc ]]; then
+        echo "Error: expected failed verification, but return code was $verify_rc"
+        exit $verify_rc
+fi
+set -e
+
+echo "badECDAATESTMESSAGE" > ${tmp_dir}/message_bad.bin
+
+echo "Check that signature does NOT verify for a different message..."
+set +e
+valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all --error-exitcode=5 ${tool_dir}/ecdaa verify -s ${tmp_dir}/sig.bin -g ${tmp_dir}/gpk.bin -m ${tmp_dir}/message_bad.bin
+verify_rc=$?
+if [[ 1 -ne $verify_rc ]]; then
+        echo "Error: expected failed verification, but return code was $verify_rc"
+        exit $verify_rc
+fi
+set -e


### PR DESCRIPTION
This PR:
- Streamlines the Bash scripts somewhat, to make it easier to test the library (especially with TPM support when testing against a simulator)

- Makes a trivial change to our usage of the AMCL API, which will make it easier to use newer versions of that library (also fixed a trivial issue that was upsetting static analysis tools)
- Removes a (unneeded) test that was upsetting Memcheck
  - A full justification of this removal can be found in the commit message for commit 9f0e47d
- Gets all tests working (and passing) in Travis-CI again, and fixes numerous issues with those that had arisen
  - This includes making a few trivial changes to satisfy static analysis tools (the justification of these can be found in the commit messages)
- Restructures the file I/O logic, in order to perform better error checking
  - This was in response to complaints from Coverity Scan static analysis tool
- Significantly reorganizes and augments the documentation

95% of this work I did back in the summer, then got busy and let it sit. I'm polishing it off (just finishing some documentation updates) now and getting it submitted.

fixes #90 
fixes #110 
fixes #122 
fixes #123