### PR TITLE
Use `tpm2-software/tpm2-tss` rather than `xaptum-tpm`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr
     - CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
     - AMCL_DIR=${TRAVIS_BUILD_DIR}/amcl/install
-    - XAPTUM_TPM_DIR=${TRAVIS_BUILD_DIR}/xaptum-tpm/
+    - TPM2_TSS_DIR=${TRAVIS_BUILD_DIR}/tpm2-tss/
     - IBM_TPM_DIR=${TRAVIS_BUILD_DIR}/ibm-tpm-simulator
     - ECDAA_CURVES=FP256BN,BN254,BN254CX,BLS383
     - ECDAA_BUILD_DIR=${TRAVIS_BUILD_DIR}/build
@@ -32,9 +32,13 @@ env:
     - SHARED_LIBS=ON
     - OUT_EXT_REPLACE=OFF
 
+before_install:
+  - sudo apt-get -y --no-install-recommends install autoconf-archive libgcrypt11-dev 
+  - pip install --user cpp-coveralls
+
 before_script:
   - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
-  - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
+  - .travis/install-tpm2-tss.sh ${TPM2_TSS_DIR} ${INSTALL_PREFIX}
   - .travis/install-ibm-tpm2.sh ${IBM_TPM_DIR}
   - mkdir -p ${ECDAA_BUILD_DIR}
   - pushd ${ECDAA_BUILD_DIR}
@@ -64,8 +68,6 @@ matrix:
           - TYPE=DEBUG_WITH_COVERAGE
           - BUILD_TYPE=DebugWithCoverage
           - OUT_EXT_REPLACE=ON
-        before_install:
-          - pip install --user cpp-coveralls
         after_success:
           - coveralls --exclude examples --exclude amcl
       - name: "DevDebug build"
@@ -92,10 +94,10 @@ matrix:
               - cppcheck
         before_script:
           - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
-          - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
+          - .travis/install-tpm2-tss.sh ${TPM2_TSS_DIR} ${INSTALL_PREFIX}
           - mkdir -p ${ECDAA_BUILD_DIR}
           - pushd ${ECDAA_BUILD_DIR}
-          - cmake .. -DCMAKE_BUILD_TYPE=Release -DXAPTUMTPM_LOCAL_DIR=${XAPTUM_TPM_DIR} -DCMAKE_INSTALL_PREFIX=${ECDAA_INSTALL_DIR} -DECDAA_CURVES=FP256BN
+          - cmake .. -DCMAKE_BUILD_TYPE=Release -DXAPTUMTPM_LOCAL_DIR=${TPM2_TSS_DIR} -DCMAKE_INSTALL_PREFIX=${ECDAA_INSTALL_DIR} -DECDAA_CURVES=FP256BN
           - popd
         script:
           - pushd ${ECDAA_BUILD_DIR}
@@ -125,7 +127,7 @@ matrix:
           - TYPE=SCAN_BUILD
         before_script:
           - .travis/install-amcl.sh ${AMCL_DIR} ${INSTALL_PREFIX} ${ECDAA_CURVES}
-          - .travis/install-xaptum-tpm.sh ${XAPTUM_TPM_DIR} ${INSTALL_PREFIX}
+          - .travis/install-tpm2-tss.sh ${TPM2_TSS_DIR} ${INSTALL_PREFIX}
         script:
           - .travis/run-scanbuild.sh ${TRAVIS_BUILD_DIR} ${ECDAA_BUILD_DIR}
       - name: "Sanitizers, gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ language: c
 
 compiler: gcc
 
+dist: bionic
+
 env:
   global:
     - INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr

--- a/.travis/install-tpm2-tss.sh
+++ b/.travis/install-tpm2-tss.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2018 Xaptum, Inc.
+# Copyright 2020 Xaptum, Inc.
 # 
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -22,16 +22,19 @@ if [[ $# -ne 2 ]]; then
         exit 1
 fi
 
+repo_url=https://github.com/tpm2-software/tpm2-tss
+tag=2.3.3
 source_dir="$(my_expand_path $1)"
 install_dir="$(my_expand_path $2)"
 
 rm -rf "${source_dir}"
-git clone https://github.com/xaptum/xaptum-tpm "${source_dir}"
+git clone -b $tag "${repo_url}" "${source_dir}"
+
 pushd "${source_dir}"
-mkdir -p build
-pushd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${install_dir} -DBUILD_SHARED_LIBS=On -DBUILD_TESTING=On
-cmake --build .
-cmake --build . --target install
-popd
+
+./bootstrap
+./configure --prefix=${install_dir} --disable-esapi --disable-doxygen-doc --enable-fapi=no --enable-tcti-partial-reads=no
+make -j $(nproc)
+make install
+
 popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(ECDAA_SOVERSION ${PROJECT_VERSION_MAJOR})
 
 find_package(AMCL 4.7.0 REQUIRED QUIET)
 if(ECDAA_TPM_SUPPORT)
-  find_package(xaptum-tpm 0.5.0 REQUIRED QUIET)
+  find_package(TSS2 REQUIRED QUIET)
 endif()
 
 add_compile_options(-std=c99 -Wall -Wextra -Wno-missing-field-initializers)
@@ -177,3 +177,11 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/ecdaa-config-version.cmake
   DESTINATION ${INSTALL_CONFIGDIR}
 )
+
+if(ECDAA_TPM_SUPPORT)
+  install(FILES
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/FindTSS2.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/LibFindMacros.cmake
+    DESTINATION ${INSTALL_CONFIGDIR}
+  )
+endif()

--- a/cmake/FindTSS2.cmake
+++ b/cmake/FindTSS2.cmake
@@ -1,0 +1,102 @@
+include(LibFindMacros)
+
+# Use pkg-config to get hints about paths
+libfind_pkg_check_modules(libtss2_PKGCONF libtss2-sys)
+
+###############################################################################
+# Find the include dirs
+###############################################################################
+find_path(libtss2_INCLUDE_DIR
+  NAMES tss2/
+  PATHS ${libtss2_sys_PKGCONF_INCLUDE_DIRS}
+  )
+
+###############################################################################
+# TSS2-Sys Library
+###############################################################################
+find_library(libtss2_sys_LIBRARY
+  NAMES tss2-sys
+  PATHS ${libtss2_PKGCONFIG_LIBRARY_DIRS}
+  )
+
+set(libtss2_sys_PROCESS_INCLUDES libtss2_INCLUDE_DIR)
+set(libtss2_sys_PROCESS_LIBS libtss2_sys_LIBRARY)
+
+libfind_process(libtss2_sys)
+
+if (libtss2_sys_FOUND)
+  if (NOT TARGET tss2::sys)
+
+    add_library(tss2::sys UNKNOWN IMPORTED)
+
+    set_target_properties(tss2::sys PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${libtss2_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${libtss2_sys_LIBRARY}"
+    )
+
+  endif ()
+endif ()
+
+###############################################################################
+# TSS2-TCTI-Device Library
+###############################################################################
+find_library(libtss2_tcti_device_LIBRARY
+  NAMES tss2-tcti-device
+  PATHS ${libtss2_PKGCONFIG_LIBRARY_DIRS}
+  )
+
+set(libtss2_tcti_device_PROCESS_INCLUDES libtss2_INCLUDE_DIR)
+set(libtss2_tcti_device_PROCESS_LIBS libtss2_tcti_device_LIBRARY)
+
+libfind_process(libtss2_tcti_device)
+
+if (libtss2_tcti_device_FOUND)
+  if (NOT TARGET tss2::tcti_device)
+
+    add_library(tss2::tcti_device UNKNOWN IMPORTED)
+
+    set_target_properties(tss2::tcti_device PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${libtss2_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${libtss2_tcti_device_LIBRARY}"
+    )
+
+  endif ()
+endif ()
+
+###############################################################################
+# TSS2-TCTI-MSSIM Library
+###############################################################################
+find_library(libtss2_tcti_mssim_LIBRARY
+  NAMES tss2-tcti-mssim
+  PATHS ${libtss2_PKGCONFIG_LIBRARY_DIRS}
+  )
+
+set(libtss2_tcti_mssim_PROCESS_INCLUDES libtss2_INCLUDE_DIR)
+set(libtss2_tcti_mssim_PROCESS_LIBS libtss2_tcti_mssim_LIBRARY)
+
+libfind_process(libtss2_tcti_mssim)
+
+if (libtss2_tcti_mssim_FOUND)
+  if (NOT TARGET tss2::tcti_mssim)
+
+    add_library(tss2::tcti_mssim UNKNOWN IMPORTED)
+
+    set_target_properties(tss2::tcti_mssim PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${libtss2_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${libtss2_tcti_mssim_LIBRARY}"
+    )
+
+  endif ()
+endif ()
+
+###############################################################################
+# Indicate package was found
+###############################################################################
+if (libtss2_sys_FOUND AND libtss2_tcti_device_FOUND AND libtss2_tcti_mssim_FOUND)
+  set(TSS2_FOUND TRUE)
+else()
+  set(TSS2_FOUND FALSE)
+endif()

--- a/cmake/LibFindMacros.cmake
+++ b/cmake/LibFindMacros.cmake
@@ -1,0 +1,266 @@
+# Version 2.2
+# Public Domain, originally written by Lasse Kärkkäinen <tronic>
+# Maintained at https://github.com/Tronic/cmake-modules
+# Please send your improvements as pull requests on Github.
+
+# Find another package and make it a dependency of the current package.
+# This also automatically forwards the "REQUIRED" argument.
+# Usage: libfind_package(<prefix> <another package> [extra args to find_package])
+macro (libfind_package PREFIX PKG)
+  set(${PREFIX}_args ${PKG} ${ARGN})
+  if (${PREFIX}_FIND_REQUIRED)
+    set(${PREFIX}_args ${${PREFIX}_args} REQUIRED)
+  endif()
+  find_package(${${PREFIX}_args})
+  set(${PREFIX}_DEPENDENCIES ${${PREFIX}_DEPENDENCIES};${PKG})
+  unset(${PREFIX}_args)
+endmacro()
+
+# A simple wrapper to make pkg-config searches a bit easier.
+# Works the same as CMake's internal pkg_check_modules but is always quiet.
+macro (libfind_pkg_check_modules)
+  find_package(PkgConfig QUIET)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(${ARGN} QUIET)
+  endif()
+endmacro()
+
+# Avoid useless copy&pasta by doing what most simple libraries do anyway:
+# pkg-config, find headers, find library.
+# Usage: libfind_pkg_detect(<prefix> <pkg-config args> FIND_PATH <name> [other args] FIND_LIBRARY <name> [other args])
+# E.g. libfind_pkg_detect(SDL2 sdl2 FIND_PATH SDL.h PATH_SUFFIXES SDL2 FIND_LIBRARY SDL2)
+function (libfind_pkg_detect PREFIX)
+  # Parse arguments
+  set(argname pkgargs)
+  foreach (i ${ARGN})
+    if ("${i}" STREQUAL "FIND_PATH")
+      set(argname pathargs)
+    elseif ("${i}" STREQUAL "FIND_LIBRARY")
+      set(argname libraryargs)
+    else()
+      set(${argname} ${${argname}} ${i})
+    endif()
+  endforeach()
+  if (NOT pkgargs)
+    message(FATAL_ERROR "libfind_pkg_detect requires at least a pkg_config package name to be passed.")
+  endif()
+  # Find library
+  libfind_pkg_check_modules(${PREFIX}_PKGCONF ${pkgargs})
+  if (pathargs)
+    find_path(${PREFIX}_INCLUDE_DIR NAMES ${pathargs} HINTS ${${PREFIX}_PKGCONF_INCLUDE_DIRS})
+  endif()
+  if (libraryargs)
+    find_library(${PREFIX}_LIBRARY NAMES ${libraryargs} HINTS ${${PREFIX}_PKGCONF_LIBRARY_DIRS})
+  endif()
+endfunction()
+
+# Extracts a version #define from a version.h file, output stored to <PREFIX>_VERSION.
+# Usage: libfind_version_header(Foobar foobar/version.h FOOBAR_VERSION_STR)
+# Fourth argument "QUIET" may be used for silently testing different define names.
+# This function does nothing if the version variable is already defined.
+function (libfind_version_header PREFIX VERSION_H DEFINE_NAME)
+  # Skip processing if we already have a version or if the include dir was not found
+  if (${PREFIX}_VERSION OR NOT ${PREFIX}_INCLUDE_DIR)
+    return()
+  endif()
+  set(quiet ${${PREFIX}_FIND_QUIETLY})
+  # Process optional arguments
+  foreach(arg ${ARGN})
+    if (arg STREQUAL "QUIET")
+      set(quiet TRUE)
+    else()
+      message(AUTHOR_WARNING "Unknown argument ${arg} to libfind_version_header ignored.")
+    endif()
+  endforeach()
+  # Read the header and parse for version number
+  set(filename "${${PREFIX}_INCLUDE_DIR}/${VERSION_H}")
+  if (NOT EXISTS ${filename})
+    if (NOT quiet)
+      message(AUTHOR_WARNING "Unable to find ${${PREFIX}_INCLUDE_DIR}/${VERSION_H}")
+    endif()
+    return()
+  endif()
+  file(READ "${filename}" header)
+  string(REGEX REPLACE ".*#[ \t]*define[ \t]*${DEFINE_NAME}[ \t]*\"([^\n]*)\".*" "\\1" match "${header}")
+  # No regex match?
+  if (match STREQUAL header)
+    if (NOT quiet)
+      message(AUTHOR_WARNING "Unable to find \#define ${DEFINE_NAME} \"<version>\" from ${${PREFIX}_INCLUDE_DIR}/${VERSION_H}")
+    endif()
+    return()
+  endif()
+  # Export the version string
+  set(${PREFIX}_VERSION "${match}" PARENT_SCOPE)
+endfunction()
+
+# Do the final processing once the paths have been detected.
+# If include dirs are needed, ${PREFIX}_PROCESS_INCLUDES should be set to contain
+# all the variables, each of which contain one include directory.
+# Ditto for ${PREFIX}_PROCESS_LIBS and library files.
+# Will set ${PREFIX}_FOUND, ${PREFIX}_INCLUDE_DIRS and ${PREFIX}_LIBRARIES.
+# Also handles errors in case library detection was required, etc.
+function (libfind_process PREFIX)
+  # Skip processing if already processed during this configuration run
+  if (${PREFIX}_FOUND)
+    return()
+  endif()
+
+  set(found TRUE)  # Start with the assumption that the package was found
+
+  # Did we find any files? Did we miss includes? These are for formatting better error messages.
+  set(some_files FALSE)
+  set(missing_headers FALSE)
+
+  # Shorthands for some variables that we need often
+  set(quiet ${${PREFIX}_FIND_QUIETLY})
+  set(required ${${PREFIX}_FIND_REQUIRED})
+  set(exactver ${${PREFIX}_FIND_VERSION_EXACT})
+  set(findver "${${PREFIX}_FIND_VERSION}")
+  set(version "${${PREFIX}_VERSION}")
+
+  # Lists of config option names (all, includes, libs)
+  unset(configopts)
+  set(includeopts ${${PREFIX}_PROCESS_INCLUDES})
+  set(libraryopts ${${PREFIX}_PROCESS_LIBS})
+
+  # Process deps to add to 
+  foreach (i ${PREFIX} ${${PREFIX}_DEPENDENCIES})
+    if (DEFINED ${i}_INCLUDE_OPTS OR DEFINED ${i}_LIBRARY_OPTS)
+      # The package seems to export option lists that we can use, woohoo!
+      list(APPEND includeopts ${${i}_INCLUDE_OPTS})
+      list(APPEND libraryopts ${${i}_LIBRARY_OPTS})
+    else()
+      # If plural forms don't exist or they equal singular forms
+      if ((NOT DEFINED ${i}_INCLUDE_DIRS AND NOT DEFINED ${i}_LIBRARIES) OR
+          ({i}_INCLUDE_DIR STREQUAL ${i}_INCLUDE_DIRS AND ${i}_LIBRARY STREQUAL ${i}_LIBRARIES))
+        # Singular forms can be used
+        if (DEFINED ${i}_INCLUDE_DIR)
+          list(APPEND includeopts ${i}_INCLUDE_DIR)
+        endif()
+        if (DEFINED ${i}_LIBRARY)
+          list(APPEND libraryopts ${i}_LIBRARY)
+        endif()
+      else()
+        # Oh no, we don't know the option names
+        message(FATAL_ERROR "We couldn't determine config variable names for ${i} includes and libs. Aieeh!")
+      endif()
+    endif()
+  endforeach()
+  
+  if (includeopts)
+    list(REMOVE_DUPLICATES includeopts)
+  endif()
+  
+  if (libraryopts)
+    list(REMOVE_DUPLICATES libraryopts)
+  endif()
+
+  string(REGEX REPLACE ".*[ ;]([^ ;]*(_INCLUDE_DIRS|_LIBRARIES))" "\\1" tmp "${includeopts} ${libraryopts}")
+  if (NOT tmp STREQUAL "${includeopts} ${libraryopts}")
+    message(AUTHOR_WARNING "Plural form ${tmp} found in config options of ${PREFIX}. This works as before but is now deprecated. Please only use singular forms INCLUDE_DIR and LIBRARY, and update your find scripts for LibFindMacros > 2.0 automatic dependency system (most often you can simply remove the PROCESS variables entirely).")
+  endif()
+
+  # Include/library names separated by spaces (notice: not CMake lists)
+  unset(includes)
+  unset(libs)
+
+  # Process all includes and set found false if any are missing
+  foreach (i ${includeopts})
+    list(APPEND configopts ${i})
+    if (NOT "${${i}}" STREQUAL "${i}-NOTFOUND")
+      list(APPEND includes "${${i}}")
+    else()
+      set(found FALSE)
+      set(missing_headers TRUE)
+    endif()
+  endforeach()
+
+  # Process all libraries and set found false if any are missing
+  foreach (i ${libraryopts})
+    list(APPEND configopts ${i})
+    if (NOT "${${i}}" STREQUAL "${i}-NOTFOUND")
+      list(APPEND libs "${${i}}")
+    else()
+      set (found FALSE)
+    endif()
+  endforeach()
+
+  # Version checks
+  if (found AND findver)
+    if (NOT version)
+      message(WARNING "The find module for ${PREFIX} does not provide version information, so we'll just assume that it is OK. Please fix the module or remove package version requirements to get rid of this warning.")
+    elseif (version VERSION_LESS findver OR (exactver AND NOT version VERSION_EQUAL findver))
+      set(found FALSE)
+      set(version_unsuitable TRUE)
+    endif()
+  endif()
+
+  # If all-OK, hide all config options, export variables, print status and exit
+  if (found)
+    foreach (i ${configopts})
+      mark_as_advanced(${i})
+    endforeach()
+    if (NOT quiet)
+      message(STATUS "Found ${PREFIX} ${${PREFIX}_VERSION}")
+      if (LIBFIND_DEBUG)
+        message(STATUS "  ${PREFIX}_DEPENDENCIES=${${PREFIX}_DEPENDENCIES}")
+        message(STATUS "  ${PREFIX}_INCLUDE_OPTS=${includeopts}")
+        message(STATUS "  ${PREFIX}_INCLUDE_DIRS=${includes}")
+        message(STATUS "  ${PREFIX}_LIBRARY_OPTS=${libraryopts}")
+        message(STATUS "  ${PREFIX}_LIBRARIES=${libs}")
+      endif()
+    endif()
+    set (${PREFIX}_INCLUDE_OPTS ${includeopts} PARENT_SCOPE)
+    set (${PREFIX}_LIBRARY_OPTS ${libraryopts} PARENT_SCOPE)
+    set (${PREFIX}_INCLUDE_DIRS ${includes} PARENT_SCOPE)
+    set (${PREFIX}_LIBRARIES ${libs} PARENT_SCOPE)
+    set (${PREFIX}_FOUND TRUE PARENT_SCOPE)
+    return()
+  endif()
+
+  # Format messages for debug info and the type of error
+  set(vars "Relevant CMake configuration variables:\n")
+  foreach (i ${configopts})
+    mark_as_advanced(CLEAR ${i})
+    set(val ${${i}})
+    if ("${val}" STREQUAL "${i}-NOTFOUND")
+      set (val "<not found>")
+    elseif (val AND NOT EXISTS ${val})
+      set (val "${val}  (does not exist)")
+    else()
+      set(some_files TRUE)
+    endif()
+    set(vars "${vars}  ${i}=${val}\n")
+  endforeach()
+  set(vars "${vars}You may use CMake GUI, cmake -D or ccmake to modify the values. Delete CMakeCache.txt to discard all values and force full re-detection if necessary.\n")
+  if (version_unsuitable)
+    set(msg "${PREFIX} ${${PREFIX}_VERSION} was found but")
+    if (exactver)
+      set(msg "${msg} only version ${findver} is acceptable.")
+    else()
+      set(msg "${msg} version ${findver} is the minimum requirement.")
+    endif()
+  else()
+    if (missing_headers)
+      set(msg "We could not find development headers for ${PREFIX}. Do you have the necessary dev package installed?")
+    elseif (some_files)
+      set(msg "We only found some files of ${PREFIX}, not all of them. Perhaps your installation is incomplete or maybe we just didn't look in the right place?")
+      if(findver)
+        set(msg "${msg} This could also be caused by incompatible version (if it helps, at least ${PREFIX} ${findver} should work).")
+      endif()
+    else()
+      set(msg "We were unable to find package ${PREFIX}.")
+    endif()
+  endif()
+
+  # Fatal error out if REQUIRED
+  if (required)
+    set(msg "REQUIRED PACKAGE NOT FOUND\n${msg} This package is REQUIRED and you need to install it or adjust CMake configuration in order to continue building ${CMAKE_PROJECT_NAME}.")
+    message(FATAL_ERROR "${msg}\n${vars}")
+  endif()
+  # Otherwise just print a nasty warning
+  if (NOT quiet)
+    message(WARNING "WARNING: MISSING PACKAGE\n${msg} This package is NOT REQUIRED and you may ignore this warning but by doing so you may miss some functionality of ${CMAKE_PROJECT_NAME}. \n${vars}")
+  endif()
+endfunction()
+

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -9,9 +9,8 @@
 * [AMCL](https://github.com/xaptum/amcl) (version 4.7)
   * Built with the support for the necessary curves
   * This library provides the pairing-based cryptography primitives
-* [xaptum-tpm](https://github.com/xaptum/xaptum-tpm) (version 0.5.0 or higher)
+* [tpm2-tss](https://github.com/tpm2-software/tpm2-tss) (version 2.3.3 or higher)
   * Only required if building ECDAA with TPM support
-  * This library provides a minimal interface to a TPM 2.0 chip
 
 ## Pairing-friendly Curves
 
@@ -50,8 +49,8 @@ export CMAKE_PREFIX_PATH=$(pwd)/deps
 # Build the AMCL library
 ../.travis/install-amcl.sh ./amcl ./deps ${ECDAA_CURVES}
 
-# Build the xaptum-tpm library (if building with TPM support)
-../.travis/install-xaptum-tpm.sh ./xaptum-tpm ./deps
+# Build the tpm2-tss library (if building with TPM support)
+../.travis/install-tpm2-tss.sh ./tpm2-tss ./deps
 ```
 
 ### Building the ECDAA libraries and CLI tool

--- a/doc/TESTS.md
+++ b/doc/TESTS.md
@@ -48,23 +48,18 @@ Note that the simulator requires OpenSSL libraries and header files to be availa
 ### Key Creation for a Physical TPM
 
 If using a physical TPM for the tests, the required ECDAA signing key can
-be created and loaded in the TPM using a test program in the `xaptum-tpm` project
-if you built that project from source:
+be created and loaded in the TPM using the test utility
+`testBin/ecdaa-create_tpm_key-util` in the build directory:
 ```bash
-# Use the copy of the xaptum-tpm project
-cd xaptum-tpm/build/testBin
+... change directory to the build directory ...
 
 # Run the key-creation program
-./create_load_evict-test
-
-# Copy the output files to the test directory
-cp pub_key.txt ../../../test/tpm
-cp handle.txt ../../../test/tpm
+./testBin/ecdaa-create_tpm_key-util test/tpm/pub_key.txt test/tpm/handle.txt
 ```
 
 The tests will now be able to use this key.
 
-NOTE: This program must only be run against a TPM on which you have Platform authorization,
+NOTE: This program must only be run against a TPM on which you have LOCKOUT and ENDORSEMENT authorization,
 and which holds no important data.
 The preparation program runs `TPM2_Clear`!
 

--- a/ecdaa-config.cmake.in
+++ b/ecdaa-config.cmake.in
@@ -10,7 +10,7 @@ list(APPEND CMAKE_MODULE_PATH ${ecdaa_CMAKE_DIR})
 
 find_dependency(AMCL 4.7.0)
 if(ECDAA_TPM_SUPPORT)
-  find_dependency(xaptum-tpm 0.5.0)
+  find_dependency(TSS2)
 endif()
 
 list(REMOVE_AT CMAKE_MODULE_PATH -1)

--- a/libecdaa-tpm/CMakeLists.txt
+++ b/libecdaa-tpm/CMakeLists.txt
@@ -69,7 +69,7 @@ if (BUILD_SHARED_LIBS)
 
         target_link_libraries(ecdaa-tpm
           PUBLIC ecdaa
-          PUBLIC xaptum-tpm::xaptum-tpm 
+          PUBLIC tss2::sys
           PUBLIC AMCL::AMCL
         )
 
@@ -112,7 +112,7 @@ if (BUILD_STATIC_LIBS)
 
         target_link_libraries(${STATIC_TARGET}
           PUBLIC ecdaa_static
-          PUBLIC xaptum-tpm::xaptum-tpm
+          PUBLIC tss2::sys
           PUBLIC AMCL::AMCL
         )
 

--- a/libecdaa-tpm/include/ecdaa-tpm/tpm_context.h
+++ b/libecdaa-tpm/include/ecdaa-tpm/tpm_context.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,15 +35,11 @@ struct ecdaa_tpm_context {
 
     TSS2_SYS_CONTEXT *sapi_context;
     uint16_t commit_counter;
-    TPM_HANDLE key_handle;
+    TPM2_HANDLE key_handle;
 
-    TPMS_AUTH_COMMAND key_authentication;
-    TPMS_AUTH_COMMAND *key_authentication_array[1];    // for passing into functions
-    TSS2_SYS_CMD_AUTHS key_authentication_cmd;    // for passing into functions
+    TSS2L_SYS_AUTH_COMMAND key_authentication_cmd;    // for passing into functions
 
-    TPMS_AUTH_RESPONSE last_auth_response;
-    TPMS_AUTH_RESPONSE *last_auth_response_array[1];    // for passing into functions
-    TSS2_SYS_RSP_AUTHS last_auth_response_cmd;    // for passing into functions
+    TSS2L_SYS_AUTH_RESPONSE last_auth_response_cmd;    // for passing into functions
 
     TSS2_RC last_return_code;
 };
@@ -60,7 +56,7 @@ struct ecdaa_tpm_context {
  * -1 on failure
  */
 int ecdaa_tpm_context_init(struct ecdaa_tpm_context *tpm_ctx,
-                           TPM_HANDLE key_handle_in,
+                           TPM2_HANDLE key_handle_in,
                            const char *key_password,
                            uint16_t key_password_length,
                            TSS2_TCTI_CONTEXT *tcti_context);

--- a/libecdaa-tpm/tpm/sign.c
+++ b/libecdaa-tpm/tpm/sign.c
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,14 +23,14 @@ int tpm_sign(struct ecdaa_tpm_context *tpm_ctx,
              TPMT_SIGNATURE *signature)
 {
     TPMT_SIG_SCHEME inScheme;
-    inScheme.scheme = TPM_ALG_ECDAA;
-	inScheme.details.ecdaa.hashAlg = TPM_ALG_SHA256;
+    inScheme.scheme = TPM2_ALG_ECDAA;
+	inScheme.details.ecdaa.hashAlg = TPM2_ALG_SHA256;
 	inScheme.details.ecdaa.count = tpm_ctx->commit_counter;
 
     // Key _shouldn't_ be restricted, so no need for this
     TPMT_TK_HASHCHECK validation;
-	validation.tag = TPM_ST_HASHCHECK;
-	validation.hierarchy = TPM_RH_NULL;
+	validation.tag = TPM2_ST_HASHCHECK;
+	validation.hierarchy = TPM2_RH_NULL;
 	validation.digest.size = 0;
 
     tpm_ctx->last_return_code = Tss2_Sys_Sign(tpm_ctx->sapi_context,

--- a/test/member_keypair_ZZZ-tests.c
+++ b/test/member_keypair_ZZZ-tests.c
@@ -272,7 +272,7 @@ static void serialize_deserialize_secret_fp()
     sk_fp = fopen(sk_file, "rb");
     TEST_ASSERT(NULL != sk_fp);
     struct ecdaa_member_secret_key_ZZZ sk_deserialized;
-    TEST_ASSERT(0 == ecdaa_member_secret_key_ZZZ_deserialize_file(&sk_deserialized, sk_file));
+    TEST_ASSERT(0 == ecdaa_member_secret_key_ZZZ_deserialize_fp(&sk_deserialized, sk_fp));
     fclose(sk_fp);
 
     printf("\tsuccess\n");

--- a/test/tpm/CMakeLists.txt
+++ b/test/tpm/CMakeLists.txt
@@ -29,11 +29,15 @@ macro(add_tpm_test_case case_file)
   add_executable(${case_name} ${case_file} $<TARGET_OBJECTS:ecdaa_utilities> ${ECDAA_TPM_UTILS_LIST})
 
   if(BUILD_SHARED_LIBS)
-          target_link_libraries(${case_name} PRIVATE
-                                ecdaa-tpm)
+          target_link_libraries(${case_name}
+                                PRIVATE ecdaa-tpm
+                                PRIVATE tss2::tcti_device
+                                PRIVATE tss2::tcti_mssim)
   else()
-          target_link_libraries(${case_name} PRIVATE
-                                ecdaa-tpm_static)
+          target_link_libraries(${case_name}
+                                PRIVATE ecdaa-tpm_static
+                                PRIVATE tss2::tcti_device
+                                PRIVATE tss2::tcti_mssim)
   endif()
 
   target_include_directories(${case_name}

--- a/test/tpm/tpm_ZZZ-test-utils.h
+++ b/test/tpm/tpm_ZZZ-test-utils.h
@@ -49,6 +49,8 @@ int tpm_initialize(struct tpm_test_context *ctx)
     const char *mssim_conf = "host=localhost,port=2321";
     const char *device_conf = "/dev/tpm0";
 
+    memset(ctx->tcti_buffer, 0, sizeof(ctx->tcti_buffer));
+
     int ret = 0;
 
     TPM2_HANDLE key_handle = 0;

--- a/test/tpm/tpm_ZZZ-test-utils.h
+++ b/test/tpm/tpm_ZZZ-test-utils.h
@@ -21,7 +21,7 @@
 #include <ecdaa-tpm/tpm_context.h>
 
 #include <tss2/tss2_sys.h>
-#include <tss2/tss2_tcti_socket.h>
+#include <tss2/tss2_tcti_mssim.h>
 #include <tss2/tss2_tcti_device.h>
 
 #include <string.h>
@@ -31,7 +31,7 @@ const char *handle_filename = "handle.txt";
 
 static
 int read_public_key_from_files(uint8_t *public_key,
-                               TPM_HANDLE *key_handle,
+                               TPM2_HANDLE *key_handle,
                                const char *pub_key_filename,
                                const char *handle_filename);
 
@@ -46,13 +46,12 @@ struct tpm_test_context {
 static
 int tpm_initialize(struct tpm_test_context *ctx)
 {
-    const char *hostname = "localhost";
-    const char *port = "2321";
-    const char *dev_filepath = "/dev/tpm0";
+    const char *mssim_conf = "host=localhost,port=2321";
+    const char *device_conf = "/dev/tpm0";
 
     int ret = 0;
 
-    TPM_HANDLE key_handle = 0;
+    TPM2_HANDLE key_handle = 0;
 
     if (0 != read_public_key_from_files(ctx->serialized_public_key, &key_handle, pub_key_filename, handle_filename)) {
         printf("Error: error reading in public key files '%s' and '%s'\n", pub_key_filename, handle_filename);
@@ -66,24 +65,35 @@ int tpm_initialize(struct tpm_test_context *ctx)
 
     ctx->tcti_context = (TSS2_TCTI_CONTEXT*)ctx->tcti_buffer;
 #ifdef USE_TCP_TPM
-    (void)dev_filepath;
-    if (tss2_tcti_getsize_socket() > sizeof(ctx->tcti_buffer)) {
+    (void)device_conf;
+    size_t size;
+    ret = Tss2_Tcti_Mssim_Init(NULL, &size, mssim_conf);
+    if (TSS2_RC_SUCCESS != ret) {
+        printf("Failed to get allocation size for tcti context\n");
+        return -1;
+    }
+    if (size > sizeof(ctx->tcti_buffer)) {
         printf("Error: socket TCTI context size larger than pre-allocated buffer\n");
         return -1;
     }
-    ret = tss2_tcti_init_socket(hostname, port, ctx->tcti_context);
+    ret = Tss2_Tcti_Mssim_Init(ctx->tcti_context, &size, mssim_conf);
     if (TSS2_RC_SUCCESS != ret) {
         printf("Error: Unable to initialize socket TCTI context\n");
         return -1;
     }
 #else
-    (void)hostname;
-    (void)port;
-    if (tss2_tcti_getsize_device() > sizeof(ctx->tcti_buffer)) {
+    (void)mssim_conf;
+    size_t size;
+    ret = Tss2_Tcti_Device_Init(NULL, &size, device_conf);
+    if (TSS2_RC_SUCCESS != ret) {
+        printf("Failed to get allocation size for tcti context\n");
+        return -1;
+    }
+    if (size > sizeof(ctx->tcti_buffer)) {
         printf("Error: device TCTI context size larger than pre-allocated buffer\n");
         return -1;
     }
-    ret = tss2_tcti_init_device(dev_filepath, strlen(dev_filepath), ctx->tcti_context);
+    ret = Tss2_Tcti_Device_Init(ctx->tcti_context, &size, device_conf);
     if (TSS2_RC_SUCCESS != ret) {
         printf("Error: Unable to initialize device TCTI context\n");
         return -1;
@@ -105,12 +115,12 @@ void tpm_cleanup(struct tpm_test_context *ctx)
     ecdaa_tpm_context_free(&ctx->tpm_ctx);
 
     if (NULL != ctx->tcti_context) {
-        tss2_tcti_finalize(ctx->tcti_context);
+        Tss2_Tcti_Finalize(ctx->tcti_context);
     }
 }
 
 int read_public_key_from_files(uint8_t *public_key,
-                               TPM_HANDLE *key_handle,
+                               TPM2_HANDLE *key_handle,
                                const char *pub_key_filename,
                                const char *handle_filename)
 {
@@ -137,7 +147,7 @@ int read_public_key_from_files(uint8_t *public_key,
     if (NULL == handle_file_ptr)
         return -1;
     do {
-        for (int i=(sizeof(TPM_HANDLE)-1); i >= 0; i--) {
+        for (int i=(sizeof(TPM2_HANDLE)-1); i >= 0; i--) {
             unsigned byt;
             if (fscanf(handle_file_ptr, "%02X", &byt) != 1) {
                 ret = -1;

--- a/tool/member_sign_ZZZ.c
+++ b/tool/member_sign_ZZZ.c
@@ -56,7 +56,7 @@ int member_sign_ZZZ(const char* secret_key_file, const char* credential_file, co
     if (NULL != basename_file) {
         basename = basename_buffer;
 
-        int read_ret = ecdaa_read_from_file(basename_buffer, sizeof(basename_buffer), basename_file);
+        read_ret = ecdaa_read_from_file(basename_buffer, sizeof(basename_buffer), basename_file);
         if (read_ret < 0) {
             return READ_FROM_FILE_ERROR;
         }


### PR DESCRIPTION
This PR transitions this project from using `xaptum-tpm` for the "TSS" (TPM Software Stack), to the official `tpm2-software/tpm2-tss` (this is the implementation available via APT on Debian-based systems, for example).

~~TEMPORARY: The build is still failing, because Valgrind Memcheck is complaining about some uninitialized memory usage in the `tpm2-tss` library. I'll track that down (either figure out if it's our fault, or silence the warnings). But I wanted to get your feedback on the CMake stuff~~
UPDATE: The uninitialized memory usage warning from Memcheck is happening in the tpm2-tss library's "mssim" TCTI (this is the TCTI that communicates with the software simulator we run). I checked that it doesn't arise when running against a device TPM, so it appears to be just concerning the mssim TCTI (and, since the device TCTI is OK, any production usage of this library should be OK). And, our code does properly call the "Init" function for the mssim TCTI, so this appears to be a problem in their library. I silenced the warning by explicitly zero-initializing the TCTI buffer in our tests. I'll try to track down the issue and open a PR in their repo if I can, or at least open an issue there.

This PR:
- Updates the names of constants and structs etc. as necessary to use the new API
  - Other than trivial renamings, the changes involve how the "authorizations" (e.g. password) are fed into the TSS functions. The API is actually significantly improved, and now we don't have to do a bunch of ugly pointer acrobatics)
- Adds a CMake module for "finding" the tpm2-tss libraries we need (the libecdaa-tpm library uses only the `libtss2-sys` library, but the tests also use either the `libtss2-tcti-device` or `libtss2-tcti-mssim` depending on whether they communicate with the TPM via a device file or via a TCP socket, i.e. with a simulator)
- Updates the travis-ci for this change
  - This means replacing the `install-xaptum-tpm` script with a `install-tpm2-tss` one
  - We also use Ubuntu 18.04 rather than 16.04 (while nice in general, the 16.04 build had issues with a too-old version of autotools failing the tpm2-tss build)
  - Note: While Ubuntu 16.04 has a `libtss2-dev` package available, it is very old (pre `1.x.x` version), and Ubuntu 18.04 mysteriously **doesn't** have any `libtss2` package
- While making this update, I also discovered that `cppcheck` was complaining about two easy-to-fix minor issues, so this PR includes those fixes, too