### PR TITLE
Clarify usage of sign and verify for unlinkable signatures

### DIFF
--- a/libecdaa-tpm/include/ecdaa-tpm/signature_TPM_ZZZ.h
+++ b/libecdaa-tpm/include/ecdaa-tpm/signature_TPM_ZZZ.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2017 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,6 +33,9 @@ struct ecdaa_tpm_context;
 
 /*
  * Create an ECDAA signature, using a TPM.
+ *
+ * To create an unlinkable signature,
+ * `basename` must be `NULL` *and* `basename_len` must be `0`.
  *
  * Returns:
  * 0 on success

--- a/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.c
+++ b/libecdaa-tpm/schnorr-tpm/schnorr_TPM_ZZZ.c
@@ -141,6 +141,10 @@ int try_tpm_sign(TPMT_SIGNATURE *signature_out,
     //      (modular-reduce c', too).
     BIG_XXX c_prime;
     if (basename_len != 0) {
+        // If any of these is non-zero, ALL must be non-zero.
+        if (NULL == basename || NULL == K_out)
+            return -1;
+
         // 2i) Find P2 by hashing basename
         ECP_ZZZ P2;
         int32_t hash_ret = ecp_ZZZ_fromhash(&P2, basename, basename_len);

--- a/libecdaa/include/ecdaa/signature_ZZZ.h
+++ b/libecdaa/include/ecdaa/signature_ZZZ.h
@@ -36,6 +36,8 @@ struct ecdaa_group_public_key_ZZZ;
 
 /*
  * ECDAA signature.
+ *
+ * If unlinkable signature, `K` will be garbage and should be ignored.
  */
 struct ecdaa_signature_ZZZ {
     BIG_XXX c;
@@ -57,6 +59,9 @@ size_t ecdaa_signature_ZZZ_with_nym_length(void);
 /*
  * Create an ECDAA signature.
  *
+ * To create an unlinkable signature,
+ * `basename` must be `NULL` *and* `basename_len` must be `0`.
+ *
  * Returns:
  * 0 on success
  * -1 if unable to create signature
@@ -72,6 +77,9 @@ int ecdaa_signature_ZZZ_sign(struct ecdaa_signature_ZZZ *signature_out,
 
 /*
  * Verify an ECDAA signature.
+ *
+ * If verifying an unlinkable signature,
+ * `basename` must be `NULL` *and* `basename_len` must be `0`.
  *
  * Returns:
  * 0 on success

--- a/libecdaa/schnorr/schnorr_ZZZ.c
+++ b/libecdaa/schnorr/schnorr_ZZZ.c
@@ -81,6 +81,10 @@ int schnorr_sign_ZZZ(BIG_XXX *c_out,
     //      (modular-reduce c', too).
     BIG_XXX c_prime;
     if (basename_len != 0) {
+        // If any of these is non-zero, ALL must be non-zero.
+        if (NULL == basename || NULL == K_out)
+            return -1;
+
         // Compute c' = Hash( R | basepoint | public_key | L | P2 | K_out | basename | msg_in )
         uint8_t hash_input_begin[SIX_ECP_LENGTH];
         assert(6*ECP_ZZZ_LENGTH == sizeof(hash_input_begin));
@@ -157,6 +161,10 @@ int schnorr_verify_ZZZ(BIG_XXX c,
     //      (modular-reduce c'', too)
     BIG_XXX c_dbl_prime;
     if (0 != basename_len) {
+        // If any of these is non-zero, ALL must be non-zero.
+        if (NULL == basename || NULL == K)
+            return -1;
+
         // 1,2,3,4 part ii) If checking a basename signature:
         ECP_ZZZ P2;
         ECP_ZZZ L;

--- a/test/signature_ZZZ-tests.c
+++ b/test/signature_ZZZ-tests.c
@@ -38,6 +38,7 @@ static void sign_then_verify_on_rev_list();
 static void sign_then_verify_bad_basename_fails();
 static void sign_then_verify_no_basename();
 static void sign_then_verify_on_bsn_rev_list();
+static void sign_then_verify_unlinkable();
 static void lengths_same();
 static void serialize_deserialize();
 static void serialize_deserialize_file();
@@ -68,6 +69,7 @@ int main()
     sign_then_verify_bad_basename_fails();
     sign_then_verify_no_basename();
     sign_then_verify_on_bsn_rev_list();
+    sign_then_verify_unlinkable();
     lengths_same();
     serialize_deserialize();
     serialize_deserialize_file();
@@ -202,6 +204,32 @@ static void sign_then_verify_no_basename()
     TEST_ASSERT(0 == ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, fixture.basename, fixture.basename_len, &fixture.sk, &fixture.cred, test_randomness));
 
     TEST_ASSERT(0 != ecdaa_signature_ZZZ_verify(&sig, &fixture.ipk.gpk, &fixture.revocations, fixture.msg, fixture.msg_len, NULL, 0));
+
+    teardown(&fixture);
+
+    printf("\tsuccess\n");
+}
+
+static void sign_then_verify_unlinkable()
+{
+    printf("Starting signature::sign_then_verify_unlinkable...\n");
+
+    sign_and_verify_fixture fixture;
+    setup(&fixture);
+
+    struct ecdaa_signature_ZZZ sig;
+    // non-NULL basename, 0 basename_length
+    TEST_ASSERT(0 != ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, fixture.basename, 0, &fixture.sk, &fixture.cred, test_randomness));
+    // NULL basename, non-0 basename_length
+    TEST_ASSERT(0 != ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, NULL, fixture.basename_len, &fixture.sk, &fixture.cred, test_randomness));
+
+    // NULL basename, 0 basename_length
+    TEST_ASSERT(0 == ecdaa_signature_ZZZ_sign(&sig, fixture.msg, fixture.msg_len, NULL, 0, &fixture.sk, &fixture.cred, test_randomness));
+
+    TEST_ASSERT(0 == ecdaa_signature_ZZZ_verify(&sig, &fixture.ipk.gpk, &fixture.revocations, fixture.msg, fixture.msg_len, NULL, 0));
+
+    // NULL basename, non-0 basename_length
+    TEST_ASSERT(0 != ecdaa_signature_ZZZ_verify(&sig, &fixture.ipk.gpk, &fixture.revocations, fixture.msg, fixture.msg_len, NULL, fixture.basename_len));
 
     teardown(&fixture);
 


### PR DESCRIPTION
This PR:
- Clarifies (well, actually states) the documentation for the `sign` and `verify` functions when used with "unlinkable" signatures, i.e. not using a `basename`
  - In such cases, *both* `basename == NULL` *and* `basename_len == 0` must be true
- Makes the checks for those conditions in the code a little more explicit
  - Previously, this check was done in only one sub-function, and so was a little implicit
- Adds tests for this functionality

This was spurred by Issue #135 