### PR TITLE
Check for identity during hashing-to-point

### DIFF
--- a/common/amcl-extensions/ecp_ZZZ.c
+++ b/common/amcl-extensions/ecp_ZZZ.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2017 Xaptum, Inc.
+ * Copyright 2017-2021 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/common/amcl-extensions/ecp_ZZZ.c
+++ b/common/amcl-extensions/ecp_ZZZ.c
@@ -97,8 +97,6 @@ int ecp_ZZZ_deserialize(ECP_ZZZ *point_out,
 
 int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t message_length)
 {
-    // Following the Appendix of Chen and Li, 2013
-
     BIG_XXX curve_order;
     BIG_XXX_rcopy(curve_order, CURVE_Order_ZZZ);
 
@@ -109,12 +107,20 @@ int32_t ecp_ZZZ_fromhash(ECP_ZZZ *point_out, const uint8_t *message, uint32_t me
         // Check if generated point is on curve:
         //  (the 0 indicates we want the y-coord with lsb=0)
         if (ECP_ZZZ_setx(point_out, x, 0)) {
-            // If on curve, and cofactor != 1, multiply by cofactor to get on correct subgroup.
+            // If on curve, and cofactor != 1,
+            // multiply by cofactor to get on correct subgroup.
+            // If this results in the identity,
+            // we're on the low-order subgroup, so keep trying.
             BIG_XXX cofactor;
             BIG_XXX_rcopy(cofactor, CURVE_Cof_ZZZ);
             if (!BIG_XXX_isunity(cofactor)) {
                 ECP_ZZZ_mul(point_out, cofactor);
+
+                if (ECP_ZZZ_isinf(point_out)) {
+                    continue;
+                }
             }
+
             return i;
         }
     }

--- a/common/amcl-extensions/ecp_ZZZ.h
+++ b/common/amcl-extensions/ecp_ZZZ.h
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
- * Copyright 2017 Xaptum, Inc.
- * 
+ * Copyright 2017-2021 Xaptum, Inc.
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/schnorr_ZZZ-fuzz.c
+++ b/test/schnorr_ZZZ-fuzz.c
@@ -33,6 +33,8 @@
 #include <stdio.h>
 
 #define MAX_REPS 10000
+#define MAX_MSG_LEN 1024
+#define MAX_BASENAME_LEN 1024
 
 static void schnorr_repeated(int schnorr_repetitions);
 
@@ -58,11 +60,11 @@ void schnorr_repeated(int schnorr_repetitions)
 
     printf("Starting schnorr::schnorr_repeated...\n");
 
-    uint8_t *msg = (uint8_t*) "Test message";
-    uint32_t msg_len = strlen((char*)msg);
+    uint8_t msg[MAX_MSG_LEN] = {};
+    uint32_t msg_len = 0;
 
-    uint8_t *basename = (uint8_t*) "BASENAME";
-    uint32_t basename_len = strlen((char*)basename);
+    uint8_t basename[MAX_BASENAME_LEN] = {};
+    uint32_t basename_len = 0;
 
     BIG_XXX c, s, n;
     ECP_ZZZ K;
@@ -75,9 +77,21 @@ void schnorr_repeated(int schnorr_repetitions)
     BIG_XXX private;
 
     for (int i=0; i<schnorr_repetitions; ++i) {
+        // Randomize msg and msg_len
+        test_randomness(&msg_len, sizeof(msg_len));
+        msg_len = (msg_len % sizeof(msg)) + 1;
+        test_randomness(msg, msg_len);
+
+        // Randomize basename and basename_len
+        test_randomness(&basename_len, sizeof(basename_len));
+        basename_len = (basename_len % sizeof(basename)) + 1;
+        test_randomness(basename, basename_len);
+
+        // Randomize basepoint
         ecp_ZZZ_random_mod_order(&rand, test_randomness);
         ECP_ZZZ_mul(&basepoint, rand);
 
+        // Randomize private key
         ecp_ZZZ_random_mod_order(&private, test_randomness);
         ECP_ZZZ_copy(&public, &basepoint);
         ECP_ZZZ_mul(&public, private);


### PR DESCRIPTION
While little-by-little trying to update this project to the newest literature, I noticed an issue with our hashing-to-a-curve-point in the case of curves with a cofactor not-equal to 1.

As before, if the cofactor is not-equal to 1, we multiply a putative point by the cofactor to ensure we're on the prime-order sub-group. However, I believe the resulting prime-order point could wind up being the identity (basically, if the initial point has no component in the prime-order subgroup, as a direct sum)! So, in the original version of this code, I forgot to explicitly check that we haven't ended up with the identity.

This is a pretty rare (~ 1/subgroup-prime-order probability) outcome if given random hash input. However, that hash input comes from the user (it's the basename), so it's not random and it's even possible that input could be maliciously influenced.

As explained in the commit message, this identity check only needs to be done when multiplying by a non-unit cofactor, so in the typical case of cofactor==1 we don't do the identity check (it's computationally non-trivial, involving modular reduction and bignum normalizing, so good to avoid if unnecessary).

This PR also adds better fuzzing to the Schnorr primitive, especially to randomize the basename (and thus the input to the hash-to-curve-point function). As mentioned above, the check added here would trigger rarely in the case of such random input, so these new fuzz tests wouldn't have caught this. But, just figured this is a good time to improve the fuzzing (don't know why I hadn't randomized that input previously...).

NOTE: The curve used by the TPM and thus in production at Xaptum has cofactor=1, so this issue wouldn't have affected Xaptum customers. I believe the only cofactor!=1 curve currently supported by this project is `BLS383`.